### PR TITLE
Add dist make target for build packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Build packaging output
+build/


### PR DESCRIPTION
Add dist make target to be consistent with other OpenSDS projects so
build artifacts can easily be collected in a consistent way across the
different deliverables.