### PR TITLE
Rename multi-cloud docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,23 +48,23 @@ docker: build
 
 	cp $(BUILD_DIR)/api api
 	chmod 755 api/api
-	docker build api -t opensdsio/multi-cloud/api:latest
+	docker build api -t opensdsio/multi-cloud-api:latest
 
 	cp $(BUILD_DIR)/backend backend
 	chmod 755 backend/backend
-	docker build backend -t opensdsio/multi-cloud/backend:latest
+	docker build backend -t opensdsio/multi-cloud-backend:latest
 
 	cp $(BUILD_DIR)/s3 s3
 	chmod 755 s3/s3
-	docker build s3 -t opensdsio/multi-cloud/s3:latest
+	docker build s3 -t opensdsio/multi-cloud-s3:latest
 
 	cp $(BUILD_DIR)/dataflow dataflow
 	chmod 755 dataflow/dataflow
-	docker build dataflow -t opensdsio/multi-cloud/dataflow:latest
+	docker build dataflow -t opensdsio/multi-cloud-dataflow:latest
 
 	cp $(BUILD_DIR)/datamover datamover
 	chmod 755 datamover/datamover
-	docker build datamover -t opensdsio/multi-cloud/datamover:latest
+	docker build datamover -t opensdsio/multi-cloud-datamover:latest
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,4 +3,3 @@ FROM alpine:latest
 
 COPY api /api
 ENTRYPOINT ["/api"]
-

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,4 +2,3 @@ FROM alpine:latest
 
 COPY backend /backend
 ENTRYPOINT ["/backend"]
-

--- a/dataflow/Dockerfile
+++ b/dataflow/Dockerfile
@@ -2,4 +2,3 @@ FROM alpine:latest
 
 COPY dataflow /dataflow
 ENTRYPOINT ["/dataflow"]
-

--- a/datamover/Dockerfile
+++ b/datamover/Dockerfile
@@ -2,4 +2,3 @@ FROM alpine:latest
 
 COPY datamover /datamover
 ENTRYPOINT ["/datamover"]
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - zookeeper
 
   api:
-    image: opensdsio/multi-cloud/api
+    image: opensdsio/multi-cloud-api
     volumes:
       - /etc/ssl/certs:/etc/ssl/certs
     ports:
@@ -31,19 +31,19 @@ services:
       MICRO_REGISTRY: "mdns"
 
   backend:
-    image: opensdsio/multi-cloud/backend
+    image: opensdsio/multi-cloud-backend
     environment:
       MICRO_REGISTRY: "mdns"
       DB_HOST: "datastore:27017"
 
   s3:
-    image: opensdsio/multi-cloud/s3
+    image: opensdsio/multi-cloud-s3
     environment:
       MICRO_REGISTRY: "mdns"
       DB_HOST: "datastore:27017"
 
   dataflow:
-    image: opensdsio/multi-cloud/dataflow
+    image: opensdsio/multi-cloud-dataflow
     environment:
       MICRO_REGISTRY: "mdns"
       DB_HOST: "datastore:27017"
@@ -53,7 +53,7 @@ services:
       - kafka
 
   datamover:
-    image: opensdsio/multi-cloud/datamover
+    image: opensdsio/multi-cloud-datamover
     volumes:
       - /etc/ssl/certs:/etc/ssl/certs
     environment:
@@ -68,4 +68,3 @@ services:
     image: mongo
     ports:
       - 27017:27017
-

--- a/docs/installation_and_testing.md
+++ b/docs/installation_and_testing.md
@@ -77,14 +77,14 @@ You can also run the command `docker ps` to check the installation status.
 # docker ps
 
 CONTAINER ID        IMAGE                             COMMAND                  CREATED             STATUS              PORTS                                                NAMES
-dc5f0f2f1ba2        opensdsio/multi-cloud/datamover   "/datamover"             15 minutes ago      Up 15 minutes                                                            multi-cloud_datamover_1
-21b9a626f0b9        opensdsio/multi-cloud/dataflow    "/dataflow"              15 minutes ago      Up 15 minutes                                                            multi-cloud_dataflow_1
+dc5f0f2f1ba2        opensdsio/multi-cloud-datamover   "/datamover"             15 minutes ago      Up 15 minutes                                                            multi-cloud_datamover_1
+21b9a626f0b9        opensdsio/multi-cloud-dataflow    "/dataflow"              15 minutes ago      Up 15 minutes                                                            multi-cloud_dataflow_1
 300d1ad826f6        wurstmeister/kafka                "start-kafka.sh"         15 minutes ago      Up 15 minutes       0.0.0.0:9092->9092/tcp                               multi-cloud_kafka_1
 f1d81d7c0755        wurstmeister/zookeeper            "/bin/sh -c '/usr/sb…"   15 minutes ago      Up 15 minutes       22/tcp, 2888/tcp, 3888/tcp, 0.0.0.0:2181->2181/tcp   multi-cloud_zookeeper_1
-2a6dad2ce1a7        opensdsio/multi-cloud/backend     "/backend"               15 minutes ago      Up 15 minutes                                                            multi-cloud_backend_1
-e16f9c8af2b8        opensdsio/multi-cloud/s3          "/s3"                    15 minutes ago      Up 15 minutes                                                            multi-cloud_s3_1
+2a6dad2ce1a7        opensdsio/multi-cloud-backend     "/backend"               15 minutes ago      Up 15 minutes                                                            multi-cloud_backend_1
+e16f9c8af2b8        opensdsio/multi-cloud-s3          "/s3"                    15 minutes ago      Up 15 minutes                                                            multi-cloud_s3_1
 d86ebaed8203        mongo                             "docker-entrypoint.s…"   15 minutes ago      Up 15 minutes       0.0.0.0:27017->27017/tcp                             multi-cloud_datastore_1
-1063e7ed784c        opensdsio/multi-cloud/api         "/api"                   15 minutes ago      Up 15 minutes       0.0.0.0:8089->8089/tcp                               multi-cloud_api_1
+1063e7ed784c        opensdsio/multi-cloud-api         "/api"                   15 minutes ago      Up 15 minutes       0.0.0.0:8089->8089/tcp                               multi-cloud_api_1
 
 ```
 

--- a/s3/Dockerfile
+++ b/s3/Dockerfile
@@ -2,4 +2,3 @@ FROM alpine:latest
 
 COPY s3 /s3
 ENTRYPOINT ["/s3"]
-


### PR DESCRIPTION
This patch is proposed to remove some invalid characters in the name of docker images, so that we can push them into `docker.io` repository.