### PR TITLE
Specify the version of docker images of kafka.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka
+    image: wurstmeister/kafka:2.11-2.0.1
     ports:
       - "9092:9092"
     environment:


### PR DESCRIPTION
As default installing will pull the latest version of docker images, but that is not tested enough for us. So I specified the version we use for testing.