### PR TITLE
Add GCP adapter for S3 compatible interfaces and added data mover interfaces for GCP backend

### DIFF
--- a/api/pkg/s3/datastore/gcp/gcp.go
+++ b/api/pkg/s3/datastore/gcp/gcp.go
@@ -1,0 +1,320 @@
+// Copyright (c) 2019 Click2Cloud Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcp
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"encoding/base64"
+	"fmt"
+
+	"io"
+	"io/ioutil"
+	"time"
+
+	"github.com/micro/go-log"
+	backendpb "github.com/opensds/multi-cloud/backend/proto"
+	. "github.com/opensds/multi-cloud/s3/pkg/exception"
+	"github.com/opensds/multi-cloud/s3/pkg/model"
+	pb "github.com/opensds/multi-cloud/s3/proto"
+	"github.com/webrtcn/s3client"
+	. "github.com/webrtcn/s3client"
+	"github.com/webrtcn/s3client/models"
+)
+
+type GcpAdapter struct {
+	backend *backendpb.BackendDetail
+	session *s3client.Client
+}
+
+func Init(backend *backendpb.BackendDetail) *GcpAdapter {
+	endpoint := backend.Endpoint
+	AccessKeyID := backend.Access
+	AccessKeySecret := backend.Security
+	sess := s3client.NewClient(endpoint, AccessKeyID, AccessKeySecret)
+	adap := &GcpAdapter{backend: backend, session: sess}
+	return adap
+}
+
+func md5Content(data []byte) string {
+	md5Ctx := md5.New()
+	md5Ctx.Write(data)
+	cipherStr := md5Ctx.Sum(nil)
+	value := base64.StdEncoding.EncodeToString(cipherStr)
+	return value
+}
+
+func (ad *GcpAdapter) PUT(stream io.Reader, object *pb.Object, ctx context.Context) S3Error {
+	bucketName := ad.backend.BucketName
+
+	newObjectKey := object.BucketName + "/" + object.ObjectKey
+
+	if ctx.Value("operation") == "upload" {
+		bucket := ad.session.NewBucket()
+
+		GcpObject := bucket.NewObject(bucketName)
+
+		d, err := ioutil.ReadAll(stream)
+		data := []byte(d)
+		contentMD5 := md5Content(data)
+		length := int64(len(d))
+		body := ioutil.NopCloser(bytes.NewReader(data))
+
+		err = GcpObject.Create(newObjectKey, contentMD5, "", length, body, models.Private)
+
+		if err != nil {
+			log.Logf("Upload to Gcp failed:%v", err)
+			return S3Error{Code: 500, Description: "Upload to Gcp failed"}
+		} else {
+			object.LastModified = time.Now().String()[:19]
+			log.Logf("LastModified is:%v\n", object.LastModified)
+		}
+	}
+
+	return NoError
+}
+
+func (ad *GcpAdapter) GET(object *pb.Object, context context.Context, start int64, end int64) (io.ReadCloser, S3Error) {
+	newObjectKey := object.BucketName + "/" + object.ObjectKey
+
+	getObjectOption := GetObjectOption{}
+	if start != 0 || end != 0 {
+		rangeObj := Range{
+			Begin: start,
+			End:   end,
+		}
+		getObjectOption = GetObjectOption{
+			Range: &rangeObj,
+		}
+	}
+
+	if context.Value("operation") == "download" {
+		bucket := ad.session.NewBucket()
+
+		GcpObject := bucket.NewObject(ad.backend.BucketName)
+
+		getObject, err := GcpObject.Get(newObjectKey, &getObjectOption)
+		if err != nil {
+			fmt.Println(err)
+			log.Logf("Download failed:%v", err)
+			return nil, S3Error{Code: 500, Description: "Download failed"}
+		} else {
+			log.Logf("Download succeed, bytes:%d\n", getObject.ContentLength)
+
+			return getObject.Body, NoError
+		}
+	}
+
+	return nil, NoError
+}
+
+func (ad *GcpAdapter) DELETE(object *pb.DeleteObjectInput, ctx context.Context) S3Error {
+
+	bucket := ad.session.NewBucket()
+
+	newObjectKey := object.Bucket + "/" + object.Key
+
+	GcpObject := bucket.NewObject(ad.backend.BucketName)
+
+	err := GcpObject.Remove(newObjectKey)
+
+	if err != nil {
+		log.Logf("Delete object failed, err:%v\n", err)
+		return InternalError
+	}
+
+	log.Logf("Delete object %s from Gcp successfully.\n", newObjectKey)
+
+	return NoError
+}
+
+func (ad *GcpAdapter) GetObjectInfo(bucketName string, key string, context context.Context) (*pb.Object, S3Error) {
+
+	bucket := ad.backend.BucketName
+	newKey := bucketName + "/" + key
+
+	bucketO := ad.session.NewBucket()
+	bucketResp, err := bucketO.Get(bucket, newKey, "", "", 1000)
+
+	if err != nil {
+		log.Logf("Error occured during get Object Info, err:%v\n", err)
+		//log.Fatalf("Error occured during get Object Info, err:%v\n", err)
+		return nil, S3Error{Code: 500, Description: err.Error()}
+	}
+
+	for _, content := range bucketResp.Contents {
+		realKey := bucketName + "/" + key
+		if realKey != content.Key {
+			break
+		}
+		obj := &pb.Object{
+			BucketName: bucketName,
+			ObjectKey:  key,
+			Size:       content.Size,
+		}
+
+		return obj, NoError
+	}
+
+	log.Logf("Can not find specified object(%s).\n", key)
+	return nil, NoSuchObject
+}
+
+func (ad *GcpAdapter) InitMultipartUpload(object *pb.Object, context context.Context) (*pb.MultipartUpload, S3Error) {
+	bucket := ad.session.NewBucket()
+	newObjectKey := object.BucketName + "/" + object.ObjectKey
+	log.Logf("bucket = %v,newObjectKey = %v\n", bucket, newObjectKey)
+	GcpObject := bucket.NewObject(ad.backend.BucketName)
+	uploader := GcpObject.NewUploads(newObjectKey)
+	multipartUpload := &pb.MultipartUpload{}
+
+	res, err := uploader.Initiate(nil)
+
+	if err != nil {
+		log.Fatalf("Init s3 multipart upload failed, err:%v\n", err)
+		return nil, S3Error{Code: 500, Description: err.Error()}
+	} else {
+		log.Logf("Init s3 multipart upload succeed, UploadId:%s\n", res.UploadID)
+		multipartUpload.Bucket = object.BucketName
+		multipartUpload.Key = object.ObjectKey
+		multipartUpload.UploadId = res.UploadID
+		return multipartUpload, NoError
+	}
+}
+
+func (ad *GcpAdapter) UploadPart(stream io.Reader,
+	multipartUpload *pb.MultipartUpload,
+	partNumber int64, upBytes int64,
+	context context.Context) (*model.UploadPartResult, S3Error) {
+	tries := 1
+	newObjectKey := multipartUpload.Bucket + "/" + multipartUpload.Key
+	bucket := ad.session.NewBucket()
+
+	GcpObject := bucket.NewObject(ad.backend.BucketName)
+	uploader := GcpObject.NewUploads(newObjectKey)
+	for tries <= 3 {
+		d, err := ioutil.ReadAll(stream)
+		data := []byte(d)
+		body := ioutil.NopCloser(bytes.NewReader(data))
+		contentMD5 := md5Content(data)
+		//length := int64(len(data))
+		part, err := uploader.UploadPart(int(partNumber), multipartUpload.UploadId, contentMD5, "", upBytes, body)
+
+		if err != nil {
+			if tries == 3 {
+				log.Logf("[ERROR]Upload part to Gcp failed. err:%v\n", err)
+				return nil, S3Error{Code: 500, Description: "Upload failed"}
+			}
+			log.Logf("Retrying to upload part#%d ,err:%s\n", partNumber, err)
+			tries++
+		} else {
+			log.Logf("Uploaded part #%d, ETag:%s\n", partNumber, part.Etag)
+			result := &model.UploadPartResult{
+				Xmlns:      model.Xmlns,
+				ETag:       part.Etag,
+				PartNumber: partNumber}
+			return result, NoError
+		}
+	}
+
+	return nil, NoError
+}
+
+func (ad *GcpAdapter) CompleteMultipartUpload(multipartUpload *pb.MultipartUpload,
+	completeUpload *model.CompleteMultipartUpload,
+	context context.Context) (*model.CompleteMultipartUploadResult, S3Error) {
+	newObjectKey := multipartUpload.Bucket + "/" + multipartUpload.Key
+	bucket := ad.session.NewBucket()
+	GcpObject := bucket.NewObject(ad.backend.BucketName)
+	uploader := GcpObject.NewUploads(newObjectKey)
+	var completeParts []CompletePart
+	for _, p := range completeUpload.Part {
+		completePart := CompletePart{
+			Etag:       p.ETag,
+			PartNumber: int(p.PartNumber),
+		}
+		completeParts = append(completeParts, completePart)
+	}
+	resp, err := uploader.Complete(multipartUpload.UploadId, completeParts)
+	if err != nil {
+		log.Logf("completeMultipartUploadS3 failed, err:%v\n", err)
+		return nil, S3Error{Code: 500, Description: err.Error()}
+	}
+	result := &model.CompleteMultipartUploadResult{
+		Xmlns:    model.Xmlns,
+		Location: ad.backend.Endpoint,
+		Bucket:   multipartUpload.Bucket,
+		Key:      multipartUpload.Key,
+		ETag:     resp.Etag,
+	}
+
+	log.Logf("completeMultipartUploadS3 successful, resp:%v\n", resp)
+	return result, NoError
+}
+
+func (ad *GcpAdapter) AbortMultipartUpload(multipartUpload *pb.MultipartUpload, context context.Context) S3Error {
+	newObjectKey := multipartUpload.Bucket + "/" + multipartUpload.Key
+	bucket := ad.session.NewBucket()
+	GcpObject := bucket.NewObject(ad.backend.BucketName)
+	uploader := GcpObject.NewUploads(newObjectKey)
+	err := uploader.RemoveUploads(multipartUpload.UploadId)
+
+	if err != nil {
+		log.Logf("abortMultipartUploadS3 failed, err:%v\n", err)
+		return S3Error{Code: 500, Description: err.Error()}
+	} else {
+		log.Logf("abortMultipartUploadS3 successful\n")
+	}
+	return NoError
+}
+
+func (ad *GcpAdapter) ListParts(listParts *pb.ListParts, context context.Context) (*model.ListPartsOutput, S3Error) {
+	newObjectKey := listParts.Bucket + "/" + listParts.Key
+	bucket := ad.session.NewBucket()
+	GcpObject := bucket.NewObject(ad.backend.BucketName)
+	uploader := GcpObject.NewUploads(newObjectKey)
+
+	listPartsResult, err := uploader.ListPart(listParts.UploadId)
+	if err != nil {
+		log.Logf("List parts failed, err:%v\n", err)
+		return nil, S3Error{Code: 500, Description: err.Error()}
+	} else {
+		log.Logf("List parts successful\n")
+		var parts []model.Part
+		for _, p := range listPartsResult.Parts {
+			part := model.Part{
+				ETag:       p.Etag,
+				PartNumber: int64(p.PartNumber),
+			}
+			parts = append(parts, part)
+		}
+		listPartsOutput := &model.ListPartsOutput{
+			Xmlns:       model.Xmlns,
+			Key:         listPartsResult.Key,
+			Bucket:      listParts.Bucket,
+			IsTruncated: listPartsResult.IsTruncated,
+			MaxParts:    listPartsResult.MaxParts,
+			Owner: model.Owner{
+				ID:          listPartsResult.Owner.OwnerID,
+				DisplayName: listPartsResult.Owner.DisplayName,
+			},
+			UploadId: listPartsResult.UploadID,
+			Parts:    parts,
+		}
+
+		return listPartsOutput, NoError
+	}
+}

--- a/api/pkg/s3/datastore/store.go
+++ b/api/pkg/s3/datastore/store.go
@@ -16,6 +16,7 @@ package datastore
 
 import (
 	"context"
+	"github.com/opensds/multi-cloud/api/pkg/s3/datastore/gcp"
 	"io"
 
 	"github.com/opensds/multi-cloud/api/pkg/s3/datastore/ceph"
@@ -51,6 +52,9 @@ func Init(backend *backendpb.BackendDetail) (DataStoreAdapter, S3Error) {
 		return StoreAdapter, NoError
 	case "fusionstorage-object":
 		StoreAdapter = hws.Init(backend)
+		return StoreAdapter, NoError
+	case "gcp-s3":
+		StoreAdapter = gcp.Init(backend)
 		return StoreAdapter, NoError
 	default:
 		return nil, NoSuchType

--- a/backend/pkg/service/service.go
+++ b/backend/pkg/service/service.go
@@ -192,6 +192,10 @@ func (b *backendService) ListType(ctx context.Context, in *pb.ListTypeRequest, o
 			Description: "Ceph Object Storage",
 		},
 		{
+			Name:        constants.BackendTypeGcp,
+			Description: "GCP Storage",
+		},
+		{
 			Name:        constants.BackendFusionStorage,
 			Description: "Huawei Fusionstorage Object Storage",
 		},

--- a/backend/pkg/utils/constants/constants.go
+++ b/backend/pkg/utils/constants/constants.go
@@ -19,5 +19,6 @@ const (
 	BackendTypeObs       = "hw-obs"
 	BackendTypeAzure     = "azure-blob"
 	BackendTypeCeph      = "ceph-s3"
+	BackendTypeGcp       = "gcp-s3"
 	BackendFusionStorage = "fusionstorage-object"
 )

--- a/dataflow/pkg/model/dataflow_type.go
+++ b/dataflow/pkg/model/dataflow_type.go
@@ -28,6 +28,7 @@ var (
 	STOR_TYPE_AZURE_BLOB       = "azure-blob"
 	STOR_TYPE_HW_OBS           = "hw-obs"
 	STOR_TYPE_CEPH_S3          = "ceph-s3"
+	STOR_TYPE_GCP_S3           = "gcp-s3"
 	STOR_TYPE_HW_FUSIONSTORAGE = "fusionstorage-object"
 	STOR_TYPE_HW_FUSIONCLOUD   = "hw-fusioncloud"
 )

--- a/dataflow/pkg/plan/plan.go
+++ b/dataflow/pkg/plan/plan.go
@@ -246,7 +246,7 @@ func getLocation(conn *Connector) (string, error) {
 	case STOR_TYPE_OPENSDS:
 		return conn.BucketName, nil
 	case STOR_TYPE_HW_OBS, STOR_TYPE_AWS_S3, STOR_TYPE_HW_FUSIONSTORAGE, STOR_TYPE_HW_FUSIONCLOUD,
-		STOR_TYPE_AZURE_BLOB, STOR_TYPE_CEPH_S3:
+		STOR_TYPE_AZURE_BLOB, STOR_TYPE_CEPH_S3, STOR_TYPE_GCP_S3:
 		cfg := conn.ConnConfig
 		for i := 0; i < len(cfg); i++ {
 			if cfg[i].Key == "bucketname" {

--- a/dataflow/pkg/service.go
+++ b/dataflow/pkg/service.go
@@ -198,7 +198,7 @@ func fillRspConnector(out *pb.Connector, in *model.Connector) {
 	case model.STOR_TYPE_OPENSDS:
 		out.BucketName = in.BucketName
 	case model.STOR_TYPE_AWS_S3, model.STOR_TYPE_HW_OBS, model.STOR_TYPE_HW_FUSIONSTORAGE, model.STOR_TYPE_HW_FUSIONCLOUD,
-		model.STOR_TYPE_AZURE_BLOB, model.STOR_TYPE_CEPH_S3:
+		model.STOR_TYPE_AZURE_BLOB, model.STOR_TYPE_CEPH_S3, model.STOR_TYPE_GCP_S3:
 		for i := 0; i < len(in.ConnConfig); i++ {
 			out.ConnConfig = append(out.ConnConfig, &pb.KV{Key: in.ConnConfig[i].Key, Value: in.ConnConfig[i].Value})
 		}
@@ -307,7 +307,7 @@ func fillReqConnector(out *model.Connector, in *pb.Connector) error {
 		out.BucketName = in.BucketName
 		return nil
 	case model.STOR_TYPE_AWS_S3, model.STOR_TYPE_HW_OBS, model.STOR_TYPE_HW_FUSIONSTORAGE, model.STOR_TYPE_HW_FUSIONCLOUD,
-		model.STOR_TYPE_AZURE_BLOB, model.STOR_TYPE_CEPH_S3:
+		model.STOR_TYPE_AZURE_BLOB, model.STOR_TYPE_CEPH_S3, model.STOR_TYPE_GCP_S3:
 		for i := 0; i < len(in.ConnConfig); i++ {
 			out.ConnConfig = append(out.ConnConfig, model.KeyValue{Key: in.ConnConfig[i].Key, Value: in.ConnConfig[i].Value})
 		}

--- a/datamover/pkg/gcp/s3/s3mover.go
+++ b/datamover/pkg/gcp/s3/s3mover.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2018 Click2Cloud Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package Gcps3mover
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/base64"
+	"errors"
+	"io/ioutil"
+	"strconv"
+
+	"github.com/micro/go-log"
+	. "github.com/opensds/multi-cloud/datamover/pkg/utils"
+	pb "github.com/opensds/multi-cloud/datamover/proto"
+	. "github.com/webrtcn/s3client"
+	"github.com/webrtcn/s3client/models"
+)
+
+type CreateMultipartUploadOutput struct {
+	UploadID string
+}
+
+type GcpS3Mover struct {
+	downloader         *Client                      //for multipart download
+	svc                *Uploads                     //for multipart upload
+	multiUploadInitOut *CreateMultipartUploadOutput //for multipart upload
+	completeParts      []*CompletePart              //for multipart upload
+}
+
+func md5Content(data []byte) string {
+	md5Ctx := md5.New()
+	md5Ctx.Write(data)
+	cipherStr := md5Ctx.Sum(nil)
+	value := base64.StdEncoding.EncodeToString(cipherStr)
+	return value
+}
+
+func (mover *GcpS3Mover) UploadObj(objKey string, destLoca *LocationInfo, buf []byte) error {
+	log.Logf("[gcps3mover] UploadObj object, key:%s.", objKey)
+	sess := NewClient(destLoca.EndPoint, destLoca.Access, destLoca.Security)
+	bucket := sess.NewBucket()
+	gcpObject := bucket.NewObject(destLoca.BucketName)
+	contentMD5 := md5Content(buf)
+	length := int64(len(buf))
+	body := ioutil.NopCloser(bytes.NewReader(buf))
+	log.Logf("[gcps3mover] Try to upload, bucket:%s,obj:%s\n", destLoca.BucketName, objKey)
+	for tries := 1; tries <= 3; tries++ {
+		err := gcpObject.Create(objKey, contentMD5, "", length, body, models.Private)
+		if err != nil {
+			log.Logf("[gcps3mover] Upload object[%s] failed %d times, err:%v\n", objKey, tries, err)
+			if tries == 3 {
+				return err
+			}
+		} else {
+			log.Logf("[gcps3mover] Upload object[%s] successfully.", objKey)
+			return nil
+		}
+
+	}
+	log.Logf("[gcps3mover] Upload object, bucket:%s,obj:%s, should not be here.\n", destLoca.BucketName, objKey)
+	return errors.New("internal error")
+}
+
+func (mover *GcpS3Mover) DownloadObj(objKey string, srcLoca *LocationInfo, buf []byte) (size int64, err error) {
+	log.Logf("[gcps3mover] DownloadObj object, key:%s.", objKey)
+	sess := NewClient(srcLoca.EndPoint, srcLoca.Access, srcLoca.Security)
+	bucket := sess.NewBucket()
+	gcpObject := bucket.NewObject(srcLoca.BucketName)
+	var numBytes int64
+	log.Logf("[gcps3mover] Try to download, bucket:%s,obj:%s\n", srcLoca.BucketName, objKey)
+	for tries := 1; tries <= 3; tries++ {
+		getObject, err := gcpObject.Get(objKey, nil)
+		//defer getObject.Body.Close()
+		d, err := ioutil.ReadAll(getObject.Body)
+		data := []byte(d)
+		size = int64(len(data))
+		copy(buf, data)
+
+		if err != nil {
+			log.Logf("[gcps3mover]download object[bucket:%s,key:%s] failed %d times, err:%v\n",
+				srcLoca.BucketName, objKey, tries, err)
+			if tries == 3 {
+				return 0, err
+			}
+		} else {
+			numBytes = getObject.ContentLength
+			log.Logf("[gcps3mover]download object[bucket:%s,key:%s] succeed, bytes:%d\n", srcLoca.BucketName, objKey, numBytes)
+			return numBytes, err
+		}
+	}
+
+	log.Logf("[gcps3mover]download object[bucket:%s,key:%s], should not be here.\n", srcLoca.BucketName, objKey)
+	return 0, errors.New("internal error")
+}
+
+func (mover *GcpS3Mover) MultiPartDownloadInit(srcLoca *LocationInfo) error {
+	sess := NewClient(srcLoca.EndPoint, srcLoca.Access, srcLoca.Security)
+	mover.downloader = sess
+	log.Logf("[gcps3mover] MultiPartDownloadInit succeed.")
+
+	return nil
+}
+
+func (mover *GcpS3Mover) DownloadRange(objKey string, srcLoca *LocationInfo, buf []byte, start int64, end int64) (size int64, err error) {
+	log.Logf("[gcps3mover] Download object[%s] range[%d - %d]...\n", objKey, start, end)
+	//sess := NewClient(srcLoca.EndPoint, srcLoca.Access, srcLoca.Security)
+	bucket := mover.downloader.NewBucket()
+	gcpObject := bucket.NewObject(srcLoca.BucketName)
+	var getObjectOption GetObjectOption
+	rangeObj := Range{Begin: start, End: end}
+	getObjectOption = GetObjectOption{
+		Range: &rangeObj,
+	}
+	strStart := strconv.FormatInt(start, 10)
+	strEnd := strconv.FormatInt(end, 10)
+	rg := "bytes=" + strStart + "-" + strEnd
+	log.Logf("[gcps3mover] Try to download object:%s, range:=%s\n", objKey, rg)
+	for tries := 1; tries <= 3; tries++ {
+		resp, err := gcpObject.Get(objKey, &getObjectOption)
+		//defer resp.Body.Close()
+		d, err := ioutil.ReadAll(resp.Body)
+		data := []byte(d)
+		size = int64(len(data))
+		copy(buf, data)
+		if err != nil {
+			log.Logf("[gcps3mover] Download object[%s] range[%d - %d] faild %d times, err:%v\n",
+				objKey, start, end, tries, err)
+			if tries == 3 {
+				return 0, err
+			}
+		} else {
+			log.Logf("[gcps3mover] Download object[%s] range[%d - %d] succeed, bytes:%d\n", objKey, start, end, size)
+			return size, err
+		}
+	}
+
+	log.Logf("[gcps3mover] Download object[%s] range[%d - %d], should not be here.\n", objKey, start, end)
+	return 0, errors.New("internal error")
+}
+
+func (mover *GcpS3Mover) MultiPartUploadInit(objKey string, destLoca *LocationInfo) error {
+	sess := NewClient(destLoca.EndPoint, destLoca.Access, destLoca.Security)
+	bucket := sess.NewBucket()
+	gcpObject := bucket.NewObject(destLoca.BucketName)
+	mover.svc = gcpObject.NewUploads(objKey)
+	log.Logf("[gcps3mover] Try to init multipart upload[objkey:%s].\n", objKey)
+	for tries := 1; tries <= 3; tries++ {
+
+		resp, err := mover.svc.Initiate(nil)
+		if err != nil {
+			log.Logf("[gcps3mover] Init multipart upload[objkey:%s] failed %d times.\n", objKey, tries)
+			if tries == 3 {
+				return err
+			}
+		} else {
+			mover.multiUploadInitOut = &CreateMultipartUploadOutput{resp.UploadID}
+			log.Logf("[gcps3mover] Init multipart upload[objkey:%s] successfully, UploadId:%s\n", objKey, resp.UploadID)
+			return nil
+		}
+	}
+	log.Logf("[gcps3mover] Init multipart upload[objkey:%s], should not be here.\n", objKey)
+	return errors.New("internal error")
+
+}
+
+func (mover *GcpS3Mover) UploadPart(objKey string, destLoca *LocationInfo, upBytes int64, buf []byte, partNumber int64, offset int64) error {
+	log.Logf("[gcps3mover] Upload range[objkey:%s, partnumber#%d,offset#%d,upBytes#%d,uploadid#%s]...\n", objKey, partNumber,
+		offset, upBytes, mover.multiUploadInitOut.UploadID)
+
+	contentMD5 := md5Content(buf)
+	length := int64(len(buf))
+	data := []byte(buf)
+	body := ioutil.NopCloser(bytes.NewReader(data))
+
+	for tries := 1; tries <= 3; tries++ {
+		upRes, err := mover.svc.UploadPart(int(partNumber), mover.multiUploadInitOut.UploadID, contentMD5, "", length, body)
+		if err != nil {
+			log.Logf("[gcps3mover] Upload range[objkey:%s, partnumber#%d, offset#%d] failed %d times, err:%v\n",
+				objKey, partNumber, offset, tries, err)
+			if tries == 3 {
+				return err
+			}
+		} else {
+
+			mover.completeParts = append(mover.completeParts, upRes)
+			log.Logf("[gcps3mover] Upload range[objkey:%s, partnumber#%d,offset#%d] successfully.\n", objKey, partNumber, offset)
+			return nil
+		}
+	}
+	log.Logf("[gcps3mover] Upload range[objkey:%s, partnumber#%d, offset#%d], should not be here.\n", objKey, partNumber, offset)
+	return errors.New("internal error")
+}
+
+func (mover *GcpS3Mover) AbortMultipartUpload(objKey string, destLoca *LocationInfo) error {
+	log.Logf("[gcps3mover] Aborting multipart upload[objkey:%s] for uploadId#%s.\n", objKey, mover.multiUploadInitOut.UploadID)
+	bucket := mover.downloader.NewBucket()
+	gcpObject := bucket.NewObject(destLoca.BucketName)
+	uploader := gcpObject.NewUploads(objKey)
+	for tries := 1; tries <= 3; tries++ {
+		err := uploader.RemoveUploads(mover.multiUploadInitOut.UploadID)
+		if err != nil {
+			log.Logf("[gcps3mover] Abort multipart upload[objkey:%s] for uploadId#%s failed %d times.\n",
+				objKey, mover.multiUploadInitOut.UploadID, tries)
+			if tries == 3 {
+				return err
+			}
+		} else {
+			log.Logf("[gcps3mover] Abort multipart upload[objkey:%s] for uploadId#%s successfully.\n",
+				objKey, mover.multiUploadInitOut.UploadID, tries)
+			return nil
+		}
+	}
+	log.Logf("[gcps3mover] Abort multipart upload[objkey:%s] for uploadId#%s, should not be here.\n",
+		objKey, mover.multiUploadInitOut.UploadID)
+	return errors.New("internal error")
+}
+
+func (mover *GcpS3Mover) CompleteMultipartUpload(objKey string, destLoca *LocationInfo) error {
+	log.Logf("[gcps3mover] Try to do CompleteMultipartUpload [objkey:%s].\n", objKey)
+	var completeParts []CompletePart
+	for _, p := range mover.completeParts {
+		completePart := CompletePart{
+			Etag:       p.Etag,
+			PartNumber: int(p.PartNumber),
+		}
+		completeParts = append(completeParts, completePart)
+	}
+	for tries := 1; tries <= 3; tries++ {
+		rsp, err := mover.svc.Complete(mover.multiUploadInitOut.UploadID, completeParts)
+		if err != nil {
+			log.Logf("[gcps3mover] completeMultipartUpload [objkey:%s] failed %d times, err:%v\n", objKey, tries, err)
+			if tries == 3 {
+				return err
+			}
+		} else {
+			log.Logf("[gcps3mover] completeMultipartUpload successfully [objkey:%s], rsp:%v\n", objKey, rsp)
+			return nil
+		}
+	}
+	log.Logf("[gcps3mover] completeMultipartUpload [objkey:%s], should not be here.\n", objKey)
+	return errors.New("internal error")
+}
+
+func (mover *GcpS3Mover) DeleteObj(objKey string, loca *LocationInfo) error {
+	sess := NewClient(loca.EndPoint, loca.Access, loca.Security)
+	bucket := sess.NewBucket()
+	gcpObject := bucket.NewObject(loca.BucketName)
+
+	err := gcpObject.Remove(objKey)
+
+	if err != nil {
+		log.Logf("[gcps3mover] Error occurred while waiting for object[%s] to be deleted.\n", objKey)
+		return err
+	}
+
+	log.Logf("[gcps3mover] Delete Object[%s] successfully.\n", objKey)
+	return nil
+}
+
+func ListObjs(loca *LocationInfo, filt *pb.Filter) ([]models.GetBucketResponseContent, error) {
+
+	sess := NewClient(loca.EndPoint, loca.Access, loca.Security)
+	bucket := sess.NewBucket()
+	var output *models.GetBucketResponse
+	var err error
+	if filt != nil {
+		output, err = bucket.Get(string(loca.BucketName), filt.Prefix, "", "", 1000)
+
+	} else {
+		output, err = bucket.Get(string(loca.BucketName), "", "", "", 1000)
+	}
+	if err != nil {
+		log.Logf("[gcps3mover] List bucket failed, err:%v\n", err)
+		return nil, err
+	}
+
+	objs := output.Contents
+
+	size := len(objs)
+
+	var out []models.GetBucketResponseContent
+	for i := 0; i < size; i++ {
+		out = append(out, models.GetBucketResponseContent{
+			Key:          objs[i].Key,
+			Size:         objs[i].Size,
+			StorageClass: objs[i].StorageClass,
+			Owner:        objs[i].Owner,
+			LastModified: objs[i].LastModified,
+			Tag:          objs[i].Tag,
+		})
+	}
+	log.Logf("[gcps3mover] Number of objects in bucket[%s] is %d.\n", loca.BucketName, len(objs))
+	return output.Contents, nil
+}

--- a/datamover/pkg/gcp/s3/s3mover.go
+++ b/datamover/pkg/gcp/s3/s3mover.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Click2Cloud Inc. All Rights Reserved.
+// Copyright (c) 2019 Click2Cloud Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
New updated PR, this PR adds GCP adapter for S3 compatible interfaces and migration scenario from GCP to AWS also tested.