### PR TITLE
IBM cloud object storage support

### DIFF
--- a/api/pkg/s3/datastore/ibm/ibmcos.go
+++ b/api/pkg/s3/datastore/ibm/ibmcos.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
-//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,14 +10,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package constants
+package ibmcos
 
-const (
-	BackendTypeAws       = "aws-s3"
-	BackendTypeIBMCos    = "ibm-cos"
-	BackendTypeObs       = "hw-obs"
-	BackendTypeAzure     = "azure-blob"
-	BackendTypeCeph      = "ceph-s3"
-	BackendTypeGcp       = "gcp-s3"
-	BackendFusionStorage = "fusionstorage-object"
+import (
+	"github.com/opensds/multi-cloud/api/pkg/s3/datastore/aws"
 )
+
+var Init = aws.Init

--- a/api/pkg/s3/datastore/store.go
+++ b/api/pkg/s3/datastore/store.go
@@ -24,6 +24,7 @@ import (
 	"github.com/opensds/multi-cloud/api/pkg/s3/datastore/aws"
 	"github.com/opensds/multi-cloud/api/pkg/s3/datastore/azure"
 	"github.com/opensds/multi-cloud/api/pkg/s3/datastore/hws"
+	"github.com/opensds/multi-cloud/api/pkg/s3/datastore/ibm"
 	backendpb "github.com/opensds/multi-cloud/backend/proto"
 	. "github.com/opensds/multi-cloud/s3/pkg/exception"
 	"github.com/opensds/multi-cloud/s3/pkg/model"
@@ -46,6 +47,9 @@ func Init(backend *backendpb.BackendDetail) (DataStoreAdapter, S3Error) {
 	case "aws-s3":
 		//DbAdapter = mongo.Init(strings.Split(db.Endpoint, ","))
 		StoreAdapter = aws.Init(backend)
+		return StoreAdapter, NoError
+	case "ibm-cos":
+		StoreAdapter = ibmcos.Init(backend)
 		return StoreAdapter, NoError
 	case "ceph-s3":
 		StoreAdapter = ceph.Init(backend)

--- a/backend/pkg/service/service.go
+++ b/backend/pkg/service/service.go
@@ -199,6 +199,10 @@ func (b *backendService) ListType(ctx context.Context, in *pb.ListTypeRequest, o
 			Name:        constants.BackendFusionStorage,
 			Description: "Huawei Fusionstorage Object Storage",
 		},
+		{
+			Name:        constants.BackendTypeIBMCos,
+			Description: "IBM Cloud Object Storage",
+		},
 	}
 
 	// Filter by name

--- a/dataflow/pkg/model/dataflow_type.go
+++ b/dataflow/pkg/model/dataflow_type.go
@@ -31,6 +31,7 @@ var (
 	STOR_TYPE_GCP_S3           = "gcp-s3"
 	STOR_TYPE_HW_FUSIONSTORAGE = "fusionstorage-object"
 	STOR_TYPE_HW_FUSIONCLOUD   = "hw-fusioncloud"
+	STOR_TYPE_IBM_COS          = "ibm-cos"
 )
 
 var (

--- a/datamover/pkg/drivers/https/migration.go
+++ b/datamover/pkg/drivers/https/migration.go
@@ -21,6 +21,7 @@ import (
 	"github.com/opensds/multi-cloud/datamover/pkg/ceph/s3"
 	"github.com/opensds/multi-cloud/datamover/pkg/db"
 	"github.com/opensds/multi-cloud/datamover/pkg/hw/obs"
+	"github.com/opensds/multi-cloud/datamover/pkg/ibm/cos"
 	. "github.com/opensds/multi-cloud/datamover/pkg/utils"
 	pb "github.com/opensds/multi-cloud/datamover/proto"
 	osdss3 "github.com/opensds/multi-cloud/s3/proto"
@@ -110,7 +111,7 @@ func getConnLocation(ctx context.Context, conn *pb.Connector) (*LocationInfo, er
 			}
 			return getOsdsLocation(ctx, virtBkname, rspbk.Backend)
 		}
-	case flowtype.STOR_TYPE_AWS_S3, flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE, flowtype.STOR_TYPE_AZURE_BLOB, flowtype.STOR_TYPE_CEPH_S3, flowtype.STOR_TYPE_GCP_S3:
+	case flowtype.STOR_TYPE_AWS_S3, flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE, flowtype.STOR_TYPE_AZURE_BLOB, flowtype.STOR_TYPE_CEPH_S3, flowtype.STOR_TYPE_GCP_S3, flowtype.STOR_TYPE_IBM_COS:
 		{
 			cfg := conn.ConnConfig
 			loca := LocationInfo{}
@@ -163,6 +164,9 @@ func moveObj(obj *osdss3.Object, srcLoca *LocationInfo, destLoca *LocationInfo) 
 	case flowtype.STOR_TYPE_AWS_S3:
 		downloader = &s3mover.S3Mover{}
 		size, err = downloader.DownloadObj(downloadObjKey, srcLoca, buf)
+	case flowtype.STOR_TYPE_IBM_COS:
+		downloader = &ibmcosmover.IBMCOSMover{}
+		size, err = downloader.DownloadObj(downloadObjKey, srcLoca, buf)
 	case flowtype.STOR_TYPE_AZURE_BLOB:
 		downloader = &blobmover.BlobMover{}
 		size, err = downloader.DownloadObj(downloadObjKey, srcLoca, buf)
@@ -198,6 +202,9 @@ func moveObj(obj *osdss3.Object, srcLoca *LocationInfo, destLoca *LocationInfo) 
 	case flowtype.STOR_TYPE_AWS_S3:
 		uploader = &s3mover.S3Mover{}
 		err = uploader.UploadObj(uploadObjKey, destLoca, buf)
+	case flowtype.STOR_TYPE_IBM_COS:
+		uploader = &ibmcosmover.IBMCOSMover{}
+		err = uploader.UploadObj(uploadObjKey, destLoca, buf)
 	case flowtype.STOR_TYPE_AZURE_BLOB:
 		uploader = &blobmover.BlobMover{}
 		err = uploader.UploadObj(uploadObjKey, destLoca, buf)
@@ -224,6 +231,10 @@ func multiPartDownloadInit(srcLoca *LocationInfo) (mover MoveWorker, err error) 
 	switch srcLoca.StorType {
 	case flowtype.STOR_TYPE_AWS_S3:
 		mover := &s3mover.S3Mover{}
+		err := mover.MultiPartDownloadInit(srcLoca)
+		return mover, err
+	case flowtype.STOR_TYPE_IBM_COS:
+		mover := &ibmcosmover.IBMCOSMover{}
 		err := mover.MultiPartDownloadInit(srcLoca)
 		return mover, err
 	case flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE, flowtype.STOR_TYPE_HW_FUSIONCLOUD:
@@ -256,6 +267,10 @@ func multiPartUploadInit(objKey string, destLoca *LocationInfo) (mover MoveWorke
 		mover := &s3mover.S3Mover{}
 		err := mover.MultiPartUploadInit(objKey, destLoca)
 		return mover, err
+	case flowtype.STOR_TYPE_IBM_COS:
+		mover := &ibmcosmover.IBMCOSMover{}
+		err := mover.MultiPartUploadInit(objKey, destLoca)
+		return mover, err
 	case flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE, flowtype.STOR_TYPE_HW_FUSIONCLOUD:
 		mover := &obsmover.ObsMover{}
 		err := mover.MultiPartUploadInit(objKey, destLoca)
@@ -282,7 +297,7 @@ func multiPartUploadInit(objKey string, destLoca *LocationInfo) (mover MoveWorke
 func abortMultipartUpload(objKey string, destLoca *LocationInfo, mover MoveWorker) error {
 	switch destLoca.StorType {
 	case flowtype.STOR_TYPE_AWS_S3, flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE,
-		flowtype.STOR_TYPE_HW_FUSIONCLOUD, flowtype.STOR_TYPE_AZURE_BLOB, flowtype.STOR_TYPE_CEPH_S3, flowtype.STOR_TYPE_GCP_S3:
+		flowtype.STOR_TYPE_HW_FUSIONCLOUD, flowtype.STOR_TYPE_AZURE_BLOB, flowtype.STOR_TYPE_CEPH_S3, flowtype.STOR_TYPE_GCP_S3, flowtype.STOR_TYPE_IBM_COS:
 		return mover.AbortMultipartUpload(objKey, destLoca)
 	default:
 		logger.Printf("Unsupport storType[%s] to download.\n", destLoca.StorType)
@@ -294,7 +309,7 @@ func abortMultipartUpload(objKey string, destLoca *LocationInfo, mover MoveWorke
 func completeMultipartUpload(objKey string, destLoca *LocationInfo, mover MoveWorker) error {
 	switch destLoca.StorType {
 	case flowtype.STOR_TYPE_AWS_S3, flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE,
-		flowtype.STOR_TYPE_HW_FUSIONCLOUD, flowtype.STOR_TYPE_AZURE_BLOB, flowtype.STOR_TYPE_CEPH_S3, flowtype.STOR_TYPE_GCP_S3:
+		flowtype.STOR_TYPE_HW_FUSIONCLOUD, flowtype.STOR_TYPE_AZURE_BLOB, flowtype.STOR_TYPE_CEPH_S3, flowtype.STOR_TYPE_GCP_S3, flowtype.STOR_TYPE_IBM_COS:
 		return mover.CompleteMultipartUpload(objKey, destLoca)
 	default:
 		logger.Printf("Unsupport storType[%s] to download.\n", destLoca.StorType)
@@ -393,6 +408,9 @@ func deleteObj(ctx context.Context, obj *osdss3.Object, loca *LocationInfo) erro
 	switch loca.StorType {
 	case flowtype.STOR_TYPE_AWS_S3:
 		mover := s3mover.S3Mover{}
+		err = mover.DeleteObj(objKey, loca)
+	case flowtype.STOR_TYPE_IBM_COS:
+		mover := ibmcosmover.IBMCOSMover{}
 		err = mover.DeleteObj(objKey, loca)
 	case flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE, flowtype.STOR_TYPE_HW_FUSIONCLOUD:
 		mover := obsmover.ObsMover{}
@@ -555,6 +573,21 @@ func getOsdsS3Objs(ctx context.Context, conn *pb.Connector, filt *pb.Filter,
 	return srcObjs, nil
 }
 
+func getIBMCosObjs(ctx context.Context, conn *pb.Connector, filt *pb.Filter,
+	defaultSrcLoca *LocationInfo) ([]*osdss3.Object, error) {
+	//TODO(acorbellini): reuse getAWSS3Objs function
+	srcObjs := []*osdss3.Object{}
+	objs, err := ibmcosmover.ListObjs(defaultSrcLoca, filt)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(objs); i++ {
+		obj := osdss3.Object{Size: *objs[i].Size, ObjectKey: *objs[i].Key, Backend: ""}
+		srcObjs = append(srcObjs, &obj)
+	}
+	return srcObjs, nil
+}
+
 func getAwsS3Objs(ctx context.Context, conn *pb.Connector, filt *pb.Filter,
 	defaultSrcLoca *LocationInfo) ([]*osdss3.Object, error) {
 	//TODO:need to support filter
@@ -639,6 +672,8 @@ func getSourceObjs(ctx context.Context, conn *pb.Connector, filt *pb.Filter,
 		return getOsdsS3Objs(ctx, conn, filt, defaultSrcLoca)
 	case flowtype.STOR_TYPE_AWS_S3:
 		return getAwsS3Objs(ctx, conn, filt, defaultSrcLoca)
+	case flowtype.STOR_TYPE_IBM_COS:
+		return getIBMCosObjs(ctx, conn, filt, defaultSrcLoca)
 	case flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE, flowtype.STOR_TYPE_HW_FUSIONCLOUD:
 		return getHwObjs(ctx, conn, filt, defaultSrcLoca)
 	case flowtype.STOR_TYPE_AZURE_BLOB:

--- a/datamover/pkg/ibm/cos/cosmover.go
+++ b/datamover/pkg/ibm/cos/cosmover.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
-//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,14 +10,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package constants
+package ibmcosmover
 
-const (
-	BackendTypeAws       = "aws-s3"
-	BackendTypeIBMCos    = "ibm-cos"
-	BackendTypeObs       = "hw-obs"
-	BackendTypeAzure     = "azure-blob"
-	BackendTypeCeph      = "ceph-s3"
-	BackendTypeGcp       = "gcp-s3"
-	BackendFusionStorage = "fusionstorage-object"
+import (
+	"github.com/opensds/multi-cloud/datamover/pkg/amazon/s3"
 )
+
+type IBMCOSMover = s3mover.S3Mover
+
+var ListObjs = s3mover.ListObjs


### PR DESCRIPTION
I added support for IBM COS, which is essentially a wrapper around AWS S3 (IBM COS APIs seem to be compatible, up to the point that the aws python cli can be used against an IBM COS instance). 
This is going to be the case until there is a functional go sdk for IBM COS (it is still a work in progress).
I tested the following:
 - Uploading files to buckets in a COS instance.
 - Adding multiple buckets.
 - Migrating between buckets.

Thank you all for this awesome project.
