### PR TITLE
add global id generator according to snowflake algo.

### DIFF
--- a/s3/pkg/datastore/yig/tests/utils_test.go
+++ b/s3/pkg/datastore/yig/tests/utils_test.go
@@ -1,0 +1,56 @@
+package tests
+
+import (
+	"sync"
+
+	"github.com/opensds/multi-cloud/s3/pkg/datastore/yig/utils"
+	. "gopkg.in/check.v1"
+)
+
+func (ys *YigSuite) TestGlobalId(c *C) {
+	gi, err := utils.NewGlobalIdGen()
+	c.Assert(err, Equals, nil)
+	c.Assert(gi, Not(Equals), nil)
+	ids := make(map[int64]int64)
+	count := 8192
+
+	for i := 0; i < count; i++ {
+		id := gi.GetId()
+		ids[id] = id
+	}
+
+	c.Assert(len(ids), Equals, count)
+}
+
+func (ys *YigSuite) TestGlobalIdConcurrent(c *C) {
+	var wg sync.WaitGroup
+	gi, _ := utils.NewGlobalIdGen()
+	ids := make(map[int64]int64)
+	count := 8192
+	numThreads := 100
+	idsChan := make(chan int64)
+	wg.Add(numThreads)
+
+	funcGen := func(loop int) {
+		for i := 0; i < loop; i++ {
+			id := gi.GetId()
+			idsChan <- id
+		}
+		wg.Done()
+	}
+
+	for i := 0; i < numThreads; i++ {
+		go funcGen(count)
+	}
+
+	go func() {
+		wg.Wait()
+		close(idsChan)
+	}()
+
+	for id := range idsChan {
+		ids[id] = id
+	}
+
+	c.Assert(len(ids), Equals, numThreads*count)
+}

--- a/s3/pkg/datastore/yig/tests/utils_test.go
+++ b/s3/pkg/datastore/yig/tests/utils_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The OpenSDS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tests
 
 import (
@@ -7,27 +21,31 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+const (
+	NUM_ID_NEEDED            = 8192
+	NUM_CONCURRENT_REQUESTOR = 100
+)
+
 func (ys *YigSuite) TestGlobalId(c *C) {
-	gi, err := utils.NewGlobalIdGen()
+	gi, err := utils.NewGlobalIdGen(0)
 	c.Assert(err, Equals, nil)
 	c.Assert(gi, Not(Equals), nil)
 	ids := make(map[int64]int64)
-	count := 8192
 
-	for i := 0; i < count; i++ {
+	for i := 0; i < NUM_ID_NEEDED; i++ {
 		id := gi.GetId()
 		ids[id] = id
 	}
 
-	c.Assert(len(ids), Equals, count)
+	c.Assert(len(ids), Equals, NUM_ID_NEEDED)
 }
 
 func (ys *YigSuite) TestGlobalIdConcurrent(c *C) {
 	var wg sync.WaitGroup
-	gi, _ := utils.NewGlobalIdGen()
+	gi, _ := utils.NewGlobalIdGen(0)
 	ids := make(map[int64]int64)
-	count := 8192
-	numThreads := 100
+	count := NUM_ID_NEEDED
+	numThreads := NUM_CONCURRENT_REQUESTOR
 	idsChan := make(chan int64)
 	wg.Add(numThreads)
 

--- a/s3/pkg/datastore/yig/utils/global_id.go
+++ b/s3/pkg/datastore/yig/utils/global_id.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"time"
+)
+
+const (
+	START_EPOCH     int64 = 1571385784722
+	MACHINE_LEN     uint8 = 10
+	SEQ_LEN         uint8 = 12
+	TIMESTAMP_SHIFS uint8 = 22
+	MAX_MACHINE_NUM int64 = 1023
+	MAX_SEQ_NUM     int64 = 4095
+)
+
+type GlobalIdGen struct {
+	// lower bits of ip address.
+	MachineId int64
+	startTime int64
+	seq       int64
+	mux       sync.Mutex
+}
+
+func NewGlobalIdGen() (*GlobalIdGen, error) {
+	gi := &GlobalIdGen{
+		seq: 0,
+	}
+	id, err := gi.getMachineId()
+	if err != nil {
+		return nil, err
+	}
+	gi.MachineId = id
+	return gi, nil
+}
+
+func (gi *GlobalIdGen) GetId() int64 {
+	gi.mux.Lock()
+	defer gi.mux.Unlock()
+	current := time.Now().UnixNano() / 1000000
+	if gi.startTime == current {
+		gi.seq++
+		if gi.seq > MAX_SEQ_NUM {
+			// process the overflow
+			for current <= gi.startTime {
+				current = time.Now().UnixNano() / 1000000
+			}
+			gi.seq = 0
+		}
+	}
+	gi.startTime = current
+	id := int64((current-START_EPOCH)<<TIMESTAMP_SHIFS | (gi.MachineId << MACHINE_LEN) | (gi.seq))
+	return id
+}
+
+func (gi *GlobalIdGen) getMachineId() (int64, error) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return 0, err
+	}
+	for _, address := range addrs {
+		// check the address type and if it is not a loopback the display it
+		if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			ip := ipnet.IP.To4()
+			if ip != nil && (ip[0] == 10 || ip[0] == 172 && (ip[1] >= 16 && ip[1] < 32) || ip[0] == 192 && ip[1] == 168) {
+				return (int64(ip[2])<<8 + int64(ip[3])) & 0x0fff, nil
+			}
+		}
+	}
+
+	return 0, errors.New("failed to find the private ip addr")
+}

--- a/s3/pkg/datastore/yig/utils/global_id.go
+++ b/s3/pkg/datastore/yig/utils/global_id.go
@@ -59,6 +59,11 @@ func NewGlobalIdGen(machineId int64) (*GlobalIdGen, error) {
 	return gi, nil
 }
 
+/*
+* the global id is generated according to snowflake algo.
+* Please refer to https://github.com/twitter-archive/snowflake/tree/snowflake-2010.
+ */
+
 func (gi *GlobalIdGen) GetId() int64 {
 	gi.mux.Lock()
 	defer gi.mux.Unlock()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds a global id generator for yig storage driver. Because when create a multipart, we need a global unique id for the multipart upload, we can use that global id generator to generate this kind of 64-bit id.
The implementation of global id generator refers to the snowflake algo.
Also, tests are used to cover the function of global id generator.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
