### PR TITLE
fix the problem of panicing the process if there is no ceph conf…

### DIFF
--- a/s3/pkg/datastore/yig/storage/storage.go
+++ b/s3/pkg/datastore/yig/storage/storage.go
@@ -59,7 +59,7 @@ func New(cfg *config.Config) (*YigStorage, error) {
 	cephConfs, err := filepath.Glob(CephConfigPattern)
 	log.Infof("Reading Ceph conf files from %+v\n", cephConfs)
 	if err != nil || len(cephConfs) == 0 {
-		log.Fatal("PANIC: No ceph conf found")
+		log.Errorf("PANIC: No ceph conf found")
 		err = errors.New("no ceph conf found")
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func New(cfg *config.Config) (*YigStorage, error) {
 	}
 
 	if len(yig.DataStorage) == 0 {
-		log.Fatal("PANIC: No data storage can be used!")
+		log.Errorf("PANIC: No data storage can be used!")
 		err = errors.New("no working data storage")
 		return nil, err
 	}


### PR DESCRIPTION
… files for yig storage driver.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
this pr fixes the problem of panicing the process if there is no ceph conf files.
when multi-cloud s3 starts, it will try to load the storage drivers such as yig driver, but if there is no ceph conf files, yig driver will panic the process which make s3 down, in this case, the create bucket will fail.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # 701

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
