### PR TITLE
Fix wrong response body and wrong sql statement in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
     container_name: mysql
     volumes:
       - ./s3/pkg/conf/tidb.sql:/yig.sql
-    command: mysql -h tidb  -P 4000 -u root -e "create database yig character set utf8;use yig;source /yig.sql"
+    command: mysql -h tidb  -P 4000 -u root -e "create database yig character set utf8;use yig;source /yig.sql;"
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
     depends_on:

--- a/s3/pkg/service/service.go
+++ b/s3/pkg/service/service.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 
@@ -560,6 +561,10 @@ func (s *s3Service) CountObjects(ctx context.Context, in *pb.ListObjectsRequest,
 }
 
 func HandleS3Error(err error, out *pb.BaseResponse) {
+	if err == nil {
+		out.ErrorCode = http.StatusOK
+		return
+	}
 	s3err, ok := err.(S3ErrorCode)
 	if ok {
 		out.ErrorCode = int32(ErrorCodeResponse[s3err].HttpStatusCode)


### PR DESCRIPTION
Signed-off-by: sunfch <sunspot0105@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Because sql statement in docker-compose.yml is not end with semicolon，database tables cannot be created at the beginning
2. fix wrong response body when create bucket successfully

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #701

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
