### PR TITLE
Tidb data persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Build packaging output
 build/
+
+# Tidb data
+tidb_data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,7 @@ services:
       - "10080:10080"
     volumes:
       - ./s3/tidbconf/tidb.toml:/tidb.toml:ro
+      - ./tidb_data:/tmp/tidb
     command:
       - --store=mocktikv
       - --config=/tidb.toml

--- a/s3/pkg/conf/tidb.sql
+++ b/s3/pkg/conf/tidb.sql
@@ -19,10 +19,9 @@
 -- Table structure for table `buckets`
 --
 
-DROP TABLE IF EXISTS `buckets`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `buckets` (
+CREATE TABLE IF NOT EXISTS `buckets` (
   `bucketname` varchar(255) NOT NULL DEFAULT '',
   `tenantid` varchar(255) DEFAULT NULL,
   `userid` varchar(255) DEFAULT NULL,
@@ -46,10 +45,9 @@ CREATE TABLE `buckets` (
 -- Table structure for table `cluster`
 --
 
-DROP TABLE IF EXISTS `cluster`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `cluster` (
+CREATE TABLE IF NOT EXISTS `cluster` (
   `fsid` varchar(255) DEFAULT NULL,
   `pool` varchar(255) DEFAULT NULL,
   `weight` int(11) DEFAULT NULL,
@@ -61,10 +59,9 @@ CREATE TABLE `cluster` (
 -- Table structure for table `gc`
 --
 
-DROP TABLE IF EXISTS `gc`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `gc` (
+CREATE TABLE IF NOT EXISTS `gc` (
   `bucketname` varchar(255) DEFAULT NULL,
   `objectname` varchar(255) DEFAULT NULL,
   `version` bigint(20) UNSIGNED DEFAULT NULL,
@@ -83,10 +80,9 @@ CREATE TABLE `gc` (
 -- Table structure for table `gcpart`
 --
 
-DROP TABLE IF EXISTS `gcpart`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `gcpart` (
+CREATE TABLE IF NOT EXISTS `gcpart` (
   `partnumber` int(11) DEFAULT NULL,
   `size` bigint(20) DEFAULT NULL,
   `objectid` varchar(255) DEFAULT NULL,
@@ -105,10 +101,9 @@ CREATE TABLE `gcpart` (
 -- Table structure for table `multipartpart`
 --
 
-DROP TABLE IF EXISTS `multipartpart`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `multipartpart` (
+CREATE TABLE IF NOT EXISTS `multipartpart` (
   `partnumber` int(11) DEFAULT NULL,
   `size` bigint(20) DEFAULT NULL,
   `objectid` varchar(255) DEFAULT NULL,
@@ -127,10 +122,9 @@ CREATE TABLE `multipartpart` (
 -- Table structure for table `multiparts`
 --
 
-DROP TABLE IF EXISTS `multiparts`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `multiparts` (
+CREATE TABLE IF NOT EXISTS `multiparts` (
   `bucketname` varchar(255) DEFAULT NULL,
   `objectname` varchar(255) DEFAULT NULL,
   `uploadtime` bigint(20) UNSIGNED DEFAULT NULL,
@@ -152,10 +146,9 @@ CREATE TABLE `multiparts` (
 -- Table structure for table `objectpart`
 --
 
-DROP TABLE IF EXISTS `objectpart`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `objectpart` (
+CREATE TABLE IF NOT EXISTS `objectpart` (
   `partnumber` int(11) DEFAULT NULL,
   `size` bigint(20) DEFAULT NULL,
   `objectid` varchar(255) DEFAULT NULL,
@@ -175,10 +168,9 @@ CREATE TABLE `objectpart` (
 -- Table structure for table `objects`
 --
 
-DROP TABLE IF EXISTS `objects`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `objects` (
+CREATE TABLE IF NOT EXISTS `objects` (
   `bucketname` varchar(255) DEFAULT NULL,
   `name` varchar(255) DEFAULT NULL,
   `version` bigint(20) UNSIGNED DEFAULT NULL,
@@ -208,10 +200,9 @@ CREATE TABLE `objects` (
 -- Table structure for table `objmap`
 --
 
-DROP TABLE IF EXISTS `objmap`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `objmap` (
+CREATE TABLE IF NOT EXISTS `objmap` (
   `bucketname` varchar(255) DEFAULT NULL,
   `objectname` varchar(255) DEFAULT NULL,
   `nullvernum` bigint(20) DEFAULT NULL,
@@ -223,10 +214,9 @@ CREATE TABLE `objmap` (
 -- Table structure for table `users`
 --
 
-DROP TABLE IF EXISTS `users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `users` (
+CREATE TABLE IF NOT EXISTS `users` (
   `userid` varchar(255) DEFAULT NULL,
   `bucketname` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
@@ -244,8 +234,7 @@ CREATE TABLE `users` (
 -- Dump completed on 2018-03-20 18:26:36
 
 
-DROP TABLE IF EXISTS `lifecycle`;
-CREATE TABLE `lifecycle` (
+CREATE TABLE IF NOT EXISTS `lifecycle` (
                        `bucketname` varchar(255) DEFAULT NULL,
                        `status` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support tidb data persistence

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #716

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
How to verify:
1. Do some operations which would write data to database, or you can write data base by sql.
```release-note
mysql> select * from users;
Empty set (0.00 sec)

mysql> insert into users (userid, bucketname) VALUES ("1", "TibdDataPersistenceTest");
Query OK, 1 row affected (0.00 sec)

mysql> select * from users;
+--------+-------------------------+
| userid | bucketname              |
+--------+-------------------------+
| 1      | TibdDataPersistenceTest |
+--------+-------------------------+
1 row in set (0.00 sec)
```
2. Execute docker-compose down then docker-compose up.
```
root@node01:~/gopath/src/github.com/opensds/multi-cloud (development) # docker-compose down
Stopping multi-cloud_dataflow_1_45a215360e8f  ... done
Stopping multi-cloud_datamover_1_5dcaf7101a25 ... done
Stopping multi-cloud_s3_1_d7480a6023a8        ... done
Stopping multi-cloud_kafka_1_d1adcc887b50     ... done
Stopping redis                                ... done
Stopping multi-cloud_api_1_a6a21b214162       ... done
Stopping multi-cloud_datastore_1_1ab9ee836864 ... done
Stopping tidb                                 ... done
Stopping multi-cloud_backend_1_51bfdd601638   ... done
Stopping multi-cloud_zookeeper_1_67b5a191e827 ... done
Removing multi-cloud_dataflow_1_45a215360e8f  ... done
Removing multi-cloud_datamover_1_5dcaf7101a25 ... done
Removing multi-cloud_s3_1_d7480a6023a8        ... done
Removing mysql                                ... done
Removing multi-cloud_kafka_1_d1adcc887b50     ... done
Removing redis                                ... done
Removing multi-cloud_api_1_a6a21b214162       ... done
Removing multi-cloud_datastore_1_1ab9ee836864 ... done
Removing tidb                                 ... done
Removing multi-cloud_backend_1_51bfdd601638   ... done
Removing multi-cloud_zookeeper_1_67b5a191e827 ... done
Removing network multi-cloud_default
root@node01:~/gopath/src/github.com/opensds/multi-cloud (development) # docker-compose up -d
Creating network "multi-cloud_default" with the default driver
Creating multi-cloud_backend_1_4028695f06c9   ... done
Creating multi-cloud_zookeeper_1_4d8b84c5ea42 ... done
Creating multi-cloud_datastore_1_4fcd327d3490 ... done
Creating tidb                                 ... done
Creating multi-cloud_api_1_5f2e8ec84442       ... done
Creating redis                                ... done
Creating mysql                                ... done
Creating multi-cloud_s3_1_a2697826e667        ... done
Creating multi-cloud_kafka_1_b7e6a96a8a94     ... done
Creating multi-cloud_datamover_1_a0ae8baa4467 ... done
Creating multi-cloud_datamover_1_a0ae8baa4467 ... done
Creating multi-cloud_dataflow_1_95a9c7a4ac2c  ... done
root@node01:~/gopath/src/github.com/opensds/multi-cloud (development) #
```
3. Check whether your data is still in database.
```
mysql> select * from users;
+--------+-------------------------+
| userid | bucketname              |
+--------+-------------------------+
| 1      | TibdDataPersistenceTest |
+--------+-------------------------+
1 row in set (0.00 sec)

mysql>
```
