### PR TITLE
add Size entry in model.CompleteMultipartUploadResult and return the …

### DIFF
--- a/s3/pkg/datastore/yig/storage/multipart.go
+++ b/s3/pkg/datastore/yig/storage/multipart.go
@@ -199,6 +199,7 @@ func (yig *YigStorage) CompleteMultipartUpload(ctx context.Context, multipartUpl
 	}
 	result.ETag = hex.EncodeToString(md5Writer.Sum(nil))
 	result.ETag += "-" + strconv.Itoa(len(parts))
+	result.Size = int64(totalSize)
 	return result, nil
 }
 

--- a/s3/pkg/model/xmlstruct.go
+++ b/s3/pkg/model/xmlstruct.go
@@ -72,6 +72,7 @@ type CompleteMultipartUploadResult struct {
 	Location string `xml:"Location"`
 	Bucket   string `xml:"Bucket"`
 	Key      string `xml:"Key"`
+	Size     int64  `xml:"Size"`
 	ETag     string `xml:"ETag"`
 }
 


### PR DESCRIPTION
…total size of the object created by multipart uploading.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This pr is used to return the size of the object created by multipart uploading. 
Currently, this pr only contains the changes of yig storage backend to return the total size of multipart uploaded object, the changes for the other backends are in later pr.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
