### PR TITLE
Support migration based on CopyObject API provided by OSDS S3 service

### DIFF
--- a/datamover/pkg/drivers/https/migration.go
+++ b/datamover/pkg/drivers/https/migration.go
@@ -290,7 +290,7 @@ func runjob(in *pb.RunJobRequest) error {
 				log.Infof("ObjectMigrated:%d,TotalCapacity:%d Progress:%d\n", j.PassedCount, j.TotalCapacity, j.Progress)
 				db.DbAdapter.UpdateJob(&j)
 			}
-		case <-time.After(time.Duration(JOB_RUN_TIME_MAX) * time.Second):
+		case <-time.After(time.Duration(dur) * time.Second):
 			{
 				tmout = true
 				log.Warnln("Timout.")

--- a/datamover/pkg/drivers/https/migration.go
+++ b/datamover/pkg/drivers/https/migration.go
@@ -42,8 +42,6 @@ var JOB_RUN_TIME_MAX = 86400           //seconds, equals 1 day
 var s3client osdss3.S3Service
 var bkendclient backend.BackendService
 
-const WT_DOWLOAD = 48
-const WT_UPLOAD = 48
 const WT_MOVE = 96
 const WT_DELETE = 4
 const JobType = "migration"
@@ -266,7 +264,6 @@ func runjob(in *pb.RunJobRequest) error {
 		}
 
 		//Do migration for each object.
-		//go doMove(ctx, objs, capa, th, srcLoca, destLoca, in.RemainSource, &j)
 		go doMigrate(ctx, objs, capa, th, in, &j)
 
 		if num < int(limit) {

--- a/datamover/pkg/drivers/https/migration.go
+++ b/datamover/pkg/drivers/https/migration.go
@@ -18,9 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
 	"math"
-	"os"
 	"strconv"
 	"time"
 
@@ -30,17 +28,12 @@ import (
 	"github.com/opensds/multi-cloud/api/pkg/common"
 	"github.com/opensds/multi-cloud/backend/proto"
 	flowtype "github.com/opensds/multi-cloud/dataflow/pkg/model"
-	"github.com/opensds/multi-cloud/datamover/pkg/amazon/s3"
-	"github.com/opensds/multi-cloud/datamover/pkg/azure/blob"
-	"github.com/opensds/multi-cloud/datamover/pkg/ceph/s3"
 	"github.com/opensds/multi-cloud/datamover/pkg/db"
-	Gcps3mover "github.com/opensds/multi-cloud/datamover/pkg/gcp/s3"
-	obsmover "github.com/opensds/multi-cloud/datamover/pkg/huawei/obs"
-	ibmcosmover "github.com/opensds/multi-cloud/datamover/pkg/ibm/cos"
 	. "github.com/opensds/multi-cloud/datamover/pkg/utils"
 	pb "github.com/opensds/multi-cloud/datamover/proto"
 	s3utils "github.com/opensds/multi-cloud/s3/pkg/utils"
 	osdss3 "github.com/opensds/multi-cloud/s3/proto"
+	log "github.com/sirupsen/logrus"
 )
 
 var simuRoutines = 10
@@ -49,11 +42,11 @@ var JOB_RUN_TIME_MAX = 86400           //seconds, equals 1 day
 var s3client osdss3.S3Service
 var bkendclient backend.BackendService
 
-var logger = log.New(os.Stdout, "", log.LstdFlags)
-
 const WT_DOWLOAD = 48
 const WT_UPLOAD = 48
+const WT_MOVE = 96
 const WT_DELETE = 4
+const JobType = "migration"
 
 type Migration interface {
 	Init()
@@ -61,7 +54,7 @@ type Migration interface {
 }
 
 func Init() {
-	logger.Println("Migration init.")
+	log.Infof("Migration init.")
 	s3client = osdss3.NewS3Service("s3", client.DefaultClient)
 	bkendclient = backend.NewBackendService("backend", client.DefaultClient)
 }
@@ -70,467 +63,123 @@ func HandleMsg(msgData []byte) error {
 	var job pb.RunJobRequest
 	err := json.Unmarshal(msgData, &job)
 	if err != nil {
-		logger.Printf("unmarshal failed, err:%v\n", err)
+		log.Infof("unmarshal failed, err:%v\n", err)
 		return err
 	}
 
 	//Check the status of job, and run it if needed
 	status := db.DbAdapter.GetJobStatus(job.Id)
 	if status != flowtype.JOB_STATUS_PENDING {
-		logger.Printf("job[id#%s] is not in %s status.\n", job.Id, flowtype.JOB_STATUS_PENDING)
+		log.Infof("job[id#%s] is not in %s status.\n", job.Id, flowtype.JOB_STATUS_PENDING)
 		return nil //No need to consume this message again
 	}
 
-	logger.Printf("HandleMsg:job=%+v\n", job)
+	log.Infof("HandleMsg:job=%+v\n", job)
 	go runjob(&job)
 	return nil
 }
 
-func doMove(ctx context.Context, objs []*osdss3.Object, capa chan int64, th chan int, srcLoca *LocationInfo,
-	destLoca *LocationInfo, remainSource bool, job *flowtype.Job) {
-	//Only three routines allowed to be running at the same time
-	//th := make(chan int, simuRoutines)
-	locMap := make(map[string]*LocationInfo)
+func doMigrate(ctx context.Context, objs []*osdss3.Object, capa chan int64, th chan int, req *pb.RunJobRequest,
+	job *flowtype.Job) {
 	for i := 0; i < len(objs); i++ {
 		if objs[i].Tier == s3utils.Tier999 {
 			// archived object cannot be moved currently
-			logger.Printf("Object(key:%s) is archived, cannot be migrated.\n", objs[i].ObjectKey)
+			log.Warnf("Object(key:%s) is archived, cannot be migrated.\n", objs[i].ObjectKey)
 			continue
 		}
-		logger.Printf("************Begin to move obj(key:%s)\n", objs[i].ObjectKey)
-		go move(ctx, objs[i], capa, th, srcLoca, destLoca, remainSource, locMap, job)
+		log.Infof("************Begin to move obj(key:%s)\n", objs[i].ObjectKey)
+
 		//Create one routine
+		go migrate(ctx, objs[i], capa, th, req, job)
 		th <- 1
-		logger.Printf("doMigrate: produce 1 routine, len(th):%d.\n", len(th))
+		log.Infof("doMigrate: produce 1 routine, len(th):%d.\n", len(th))
 	}
 }
 
-func MoveObj(obj *osdss3.Object, srcLoca *LocationInfo, destLoca *LocationInfo, job *flowtype.Job) error {
-	logger.Printf("*****Move object[%s] from #%s# to #%s#, size is %d.\n", obj.ObjectKey, srcLoca.BakendName,
-		destLoca.BakendName, obj.Size)
+func CopyObj(ctx context.Context, obj *osdss3.Object, destLoca *LocationInfo, job *flowtype.Job) error {
+	log.Infof("*****Move object, size is %d.\n", obj.Size)
 	if obj.Size <= 0 {
 		return nil
 	}
-	buf := make([]byte, obj.Size)
-	var size int64 = 0
-	var err error = nil
-	var downloader, uploader MoveWorker
-	downloadObjKey := obj.ObjectKey
-	if srcLoca.VirBucket != "" {
-		downloadObjKey = srcLoca.VirBucket + "/" + downloadObjKey
+
+	req := &osdss3.CopyObjectRequest{
+		SrcObjectName:    obj.ObjectKey,
+		SrcBucketName:    obj.BucketName,
+		TargetBucketName: destLoca.BucketName,
+		TargetObjectName: obj.ObjectKey,
 	}
-	//download
-	switch srcLoca.StorType {
-	case flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE, flowtype.STOR_TYPE_HW_FUSIONCLOUD:
-		downloader = &obsmover.ObsMover{}
-		size, err = downloader.DownloadObj(downloadObjKey, srcLoca, buf)
-	case flowtype.STOR_TYPE_AWS_S3:
-		downloader = &s3mover.S3Mover{}
-		size, err = downloader.DownloadObj(downloadObjKey, srcLoca, buf)
-	case flowtype.STOR_TYPE_IBM_COS:
-		downloader = &ibmcosmover.IBMCOSMover{}
-		size, err = downloader.DownloadObj(downloadObjKey, srcLoca, buf)
-	case flowtype.STOR_TYPE_AZURE_BLOB:
-		downloader = &blobmover.BlobMover{}
-		size, err = downloader.DownloadObj(downloadObjKey, srcLoca, buf)
-	case flowtype.STOR_TYPE_CEPH_S3:
-		downloader = &cephs3mover.CephS3Mover{}
-		size, err = downloader.DownloadObj(downloadObjKey, srcLoca, buf)
-	case flowtype.STOR_TYPE_GCP_S3:
-		downloader = &Gcps3mover.GcpS3Mover{}
-		size, err = downloader.DownloadObj(downloadObjKey, srcLoca, buf)
-	default:
-		{
-			logger.Printf("not support source backend type:%v\n", srcLoca.StorType)
-			err = errors.New("not support source backend type")
-		}
-	}
+
+	_, err := s3client.CopyObject(ctx, req)
 	if err != nil {
-		logger.Printf("download object[%s] failed.", obj.ObjectKey)
-		return err
-	}
-	if job.Type == "migration" {
-		progress(job, size, WT_DOWLOAD)
+		log.Errorf("copy object[%s] failed, err:%v\n", obj.ObjectKey, err)
 	}
 
-	logger.Printf("Download object[%s] succeed, size=%d\n", obj.ObjectKey, size)
+	progress(job, obj.Size, WT_MOVE)
 
-	//upload
-	uploadObjKey := obj.ObjectKey
-	if srcLoca.VirBucket != "" {
-		uploadObjKey = destLoca.VirBucket + "/" + uploadObjKey
-	}
+	return err
+}
 
-	switch destLoca.StorType {
-	case flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE, flowtype.STOR_TYPE_HW_FUSIONCLOUD:
-		uploader = &obsmover.ObsMover{}
-		err = uploader.UploadObj(uploadObjKey, destLoca, buf)
-	case flowtype.STOR_TYPE_AWS_S3:
-		uploader = &s3mover.S3Mover{}
-		err = uploader.UploadObj(uploadObjKey, destLoca, buf)
-	case flowtype.STOR_TYPE_IBM_COS:
-		uploader = &ibmcosmover.IBMCOSMover{}
-		err = uploader.UploadObj(uploadObjKey, destLoca, buf)
-	case flowtype.STOR_TYPE_AZURE_BLOB:
-		uploader = &blobmover.BlobMover{}
-		err = uploader.UploadObj(uploadObjKey, destLoca, buf)
-	case flowtype.STOR_TYPE_CEPH_S3:
-		uploader = &cephs3mover.CephS3Mover{}
-		err = uploader.UploadObj(uploadObjKey, destLoca, buf)
-	case flowtype.STOR_TYPE_GCP_S3:
-		uploader = &Gcps3mover.GcpS3Mover{}
-		err = uploader.UploadObj(uploadObjKey, destLoca, buf)
-	default:
-		logger.Printf("not support destination backend type:%v\n", destLoca.StorType)
-		return errors.New("not support destination backend type.")
-	}
+func MultipartCopyObj(ctx context.Context, obj *osdss3.Object, destLoca *LocationInfo, job *flowtype.Job) error {
+	// This depend on multipart upload
+	log.Error("not implemented")
+	return errors.New("not implemented")
+
+	return nil
+}
+
+func deleteObj(ctx context.Context, obj *osdss3.Object) error {
+	delMetaReq := osdss3.DeleteObjectInput{Bucket: obj.BucketName, Key: obj.ObjectKey}
+	_, err := s3client.DeleteObject(ctx, &delMetaReq)
 	if err != nil {
-		logger.Printf("upload object[bucket:%s,key:%s] failed, err:%v.\n", destLoca.BucketName, uploadObjKey, err)
+		log.Infof("delete object[bucket:%s,objKey:%s] failed, err:%v\n", obj.BucketName,
+			obj.ObjectKey, err)
 	} else {
-		if job.Type == "migration" {
-			progress(job, size, WT_UPLOAD)
-		}
-		logger.Printf("upload object[bucket:%s,key:%s] successfully.\n", destLoca.BucketName, uploadObjKey)
+		log.Infof("Delete object[bucket:%s,objKey:%s] successfully.\n", obj.BucketName,
+			obj.ObjectKey)
 	}
 
 	return err
 }
 
-func multiPartDownloadInit(srcLoca *LocationInfo) (mover MoveWorker, err error) {
-	switch srcLoca.StorType {
-	case flowtype.STOR_TYPE_AWS_S3:
-		mover := &s3mover.S3Mover{}
-		err := mover.MultiPartDownloadInit(srcLoca)
-		return mover, err
-	case flowtype.STOR_TYPE_IBM_COS:
-		mover := &ibmcosmover.IBMCOSMover{}
-		err := mover.MultiPartDownloadInit(srcLoca)
-		return mover, err
-	case flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE, flowtype.STOR_TYPE_HW_FUSIONCLOUD:
-		mover := &obsmover.ObsMover{}
-		err := mover.MultiPartDownloadInit(srcLoca)
-		return mover, err
-	case flowtype.STOR_TYPE_AZURE_BLOB:
-		mover := &blobmover.BlobMover{}
-		err := mover.MultiPartDownloadInit(srcLoca)
-		return mover, err
-	case flowtype.STOR_TYPE_CEPH_S3:
-		mover := &cephs3mover.CephS3Mover{}
-		err := mover.MultiPartDownloadInit(srcLoca)
-		return mover, err
-	case flowtype.STOR_TYPE_GCP_S3:
-		mover := &Gcps3mover.GcpS3Mover{}
-		err := mover.MultiPartDownloadInit(srcLoca)
-		return mover, err
-
-	default:
-		logger.Printf("unsupport storType[%s] to init multipart download.\n", srcLoca.StorType)
-	}
-
-	return nil, errors.New("unsupport storage type.")
-}
-
-func multiPartUploadInit(objKey string, destLoca *LocationInfo) (mover MoveWorker, uploadId string, err error) {
-	uploadId = ""
-	switch destLoca.StorType {
-	case flowtype.STOR_TYPE_AWS_S3:
-		mover = &s3mover.S3Mover{}
-		uploadId, err = mover.MultiPartUploadInit(objKey, destLoca)
-		return
-	case flowtype.STOR_TYPE_IBM_COS:
-		mover = &ibmcosmover.IBMCOSMover{}
-		uploadId, err = mover.MultiPartUploadInit(objKey, destLoca)
-		return
-	case flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE, flowtype.STOR_TYPE_HW_FUSIONCLOUD:
-		mover = &obsmover.ObsMover{}
-		uploadId, err = mover.MultiPartUploadInit(objKey, destLoca)
-		return
-	case flowtype.STOR_TYPE_AZURE_BLOB:
-		mover = &blobmover.BlobMover{}
-		uploadId, err = mover.MultiPartUploadInit(objKey, destLoca)
-		return
-	case flowtype.STOR_TYPE_CEPH_S3:
-		mover = &cephs3mover.CephS3Mover{}
-		uploadId, err = mover.MultiPartUploadInit(objKey, destLoca)
-		return
-	case flowtype.STOR_TYPE_GCP_S3:
-		mover = &Gcps3mover.GcpS3Mover{}
-		uploadId, err = mover.MultiPartUploadInit(objKey, destLoca)
-		return mover, uploadId, err
-	default:
-		logger.Printf("unsupport storType[%s] to download.\n", destLoca.StorType)
-	}
-
-	return nil, uploadId, errors.New("unsupport storage type")
-}
-
-func abortMultipartUpload(objKey string, destLoca *LocationInfo, mover MoveWorker) error {
-	switch destLoca.StorType {
-	case flowtype.STOR_TYPE_AWS_S3, flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE,
-		flowtype.STOR_TYPE_HW_FUSIONCLOUD, flowtype.STOR_TYPE_AZURE_BLOB, flowtype.STOR_TYPE_CEPH_S3, flowtype.STOR_TYPE_GCP_S3, flowtype.STOR_TYPE_IBM_COS:
-		return mover.AbortMultipartUpload(objKey, destLoca)
-	default:
-		logger.Printf("unsupport storType[%s] to download.\n", destLoca.StorType)
-	}
-
-	return errors.New("unsupport storage type")
-}
-
-func completeMultipartUpload(objKey string, destLoca *LocationInfo, mover MoveWorker) error {
-	switch destLoca.StorType {
-	case flowtype.STOR_TYPE_AWS_S3, flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE,
-		flowtype.STOR_TYPE_HW_FUSIONCLOUD, flowtype.STOR_TYPE_AZURE_BLOB, flowtype.STOR_TYPE_CEPH_S3, flowtype.STOR_TYPE_GCP_S3, flowtype.STOR_TYPE_IBM_COS:
-		return mover.CompleteMultipartUpload(objKey, destLoca)
-	default:
-		logger.Printf("unsupport storType[%s] to download.\n", destLoca.StorType)
-	}
-
-	return errors.New("unsupport storage type")
-}
-
-func addMultipartUpload(objKey, virtBucket, backendName, uploadId string) {
-	// some cloud vendor, like azure, does not support user to delete uncomplete multipart upload data, and no uploadId provided,
-	// so we do not need to manage the uncomplete multipart upload data.
-	if len(uploadId) == 0 {
-		return
-	}
-
-	record := osdss3.MultipartUploadRecord{ObjectKey: objKey, Bucket: virtBucket, Backend: backendName, UploadId: uploadId}
-	record.InitTime = time.Now().Unix()
-
-	s3client.AddUploadRecord(context.Background(), &record)
-	// TODO: Need consider if add failed
-}
-
-func deleteMultipartUpload(objKey, virtBucket, backendName, uploadId string) {
-	// some cloud vendor, like azure, does not support user to delete uncomplete multipart upload data, and no uploadId provided,
-	// so we do not need to manage the uncomplete multipart upload data.
-	if len(uploadId) == 0 {
-		return
-	}
-
-	record := osdss3.MultipartUploadRecord{ObjectKey: objKey, Bucket: virtBucket, Backend: backendName, UploadId: uploadId}
-	s3client.DeleteUploadRecord(context.Background(), &record)
-}
-
-func MultipartMoveObj(obj *osdss3.Object, srcLoca *LocationInfo, destLoca *LocationInfo, job *flowtype.Job) error {
-	partCount := int64(obj.Size / PART_SIZE)
-	if obj.Size%PART_SIZE != 0 {
-		partCount++
-	}
-
-	logger.Printf("*****Move object[%s] from #%s# to #%s#, size is %d.\n", obj.ObjectKey, srcLoca.BakendName,
-		destLoca.BakendName, obj.Size)
-	downloadObjKey := obj.ObjectKey
-	if srcLoca.VirBucket != "" {
-		downloadObjKey = srcLoca.VirBucket + "/" + downloadObjKey
-	}
-	uploadObjKey := obj.ObjectKey
-	if destLoca.VirBucket != "" {
-		uploadObjKey = destLoca.VirBucket + "/" + uploadObjKey
-	}
-
-	buf := make([]byte, PART_SIZE)
-	var i int64
-	var err error
-	var uploadMover, downloadMover MoveWorker
-	var uploadId string
-	currPartSize := PART_SIZE
-	for i = 0; i < partCount; i++ {
-		partNumber := i + 1
-		offset := int64(i) * PART_SIZE
-		if i+1 == partCount {
-			currPartSize = obj.Size - offset
-			buf = nil
-			buf = make([]byte, currPartSize)
-		}
-
-		//download
-		start := offset
-		end := offset + currPartSize - 1
-		if partNumber == 1 {
-			downloadMover, err = multiPartDownloadInit(srcLoca)
-			if err != nil {
-				return err
-			}
-		}
-		readSize, err := downloadMover.DownloadRange(downloadObjKey, srcLoca, buf, start, end)
-		if err != nil {
-			return errors.New("download failed")
-		}
-		//fmt.Printf("Download part %d range[%d:%d] successfully.\n", partNumber, offset, end)
-		if int64(readSize) != currPartSize {
-			logger.Printf("internal error, currPartSize=%d, readSize=%d\n", currPartSize, readSize)
-			return errors.New(DMERR_InternalError)
-		}
-		if job.Type == "migration" {
-			progress(job, currPartSize, WT_DOWLOAD)
-		}
-
-		//upload
-		if partNumber == 1 {
-			//init multipart upload
-			uploadMover, uploadId, err = multiPartUploadInit(uploadObjKey, destLoca)
-			if err != nil {
-				return err
-			} else {
-				addMultipartUpload(obj.ObjectKey, destLoca.VirBucket, destLoca.BakendName, uploadId)
-			}
-		}
-		err1 := uploadMover.UploadPart(uploadObjKey, destLoca, currPartSize, buf, partNumber, offset)
-		if err1 != nil {
-			err := abortMultipartUpload(obj.ObjectKey, destLoca, uploadMover)
-			if err != nil {
-				logger.Printf("Abort s3 multipart upload failed, err:%v\n", err)
-			} else {
-				deleteMultipartUpload(obj.ObjectKey, destLoca.VirBucket, destLoca.BakendName, uploadId)
-			}
-			return errors.New("multipart upload failed")
-		}
-		if job.Type == "migration" {
-			progress(job, currPartSize, WT_UPLOAD)
-		}
-
-		//completeParts = append(completeParts, completePart)
-	}
-
-	err = completeMultipartUpload(uploadObjKey, destLoca, uploadMover)
-	if err != nil {
-		logger.Println(err.Error())
-		err := abortMultipartUpload(obj.ObjectKey, destLoca, uploadMover)
-		if err != nil {
-			logger.Printf("abort s3 multipart upload failed, err:%v\n", err)
-		} else {
-			deleteMultipartUpload(obj.ObjectKey, destLoca.VirBucket, destLoca.BakendName, uploadId)
-		}
-	} else {
-		deleteMultipartUpload(obj.ObjectKey, destLoca.VirBucket, destLoca.BakendName, uploadId)
-	}
-
-	return err
-}
-
-func deleteObj(ctx context.Context, obj *osdss3.Object, loca *LocationInfo) error {
-	objKey := obj.ObjectKey
-	if loca.VirBucket != "" {
-		objKey = loca.VirBucket + "/" + objKey
-	}
-	var err error = nil
-	switch loca.StorType {
-	case flowtype.STOR_TYPE_AWS_S3:
-		mover := s3mover.S3Mover{}
-		err = mover.DeleteObj(objKey, loca)
-	case flowtype.STOR_TYPE_IBM_COS:
-		mover := ibmcosmover.IBMCOSMover{}
-		err = mover.DeleteObj(objKey, loca)
-	case flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE, flowtype.STOR_TYPE_HW_FUSIONCLOUD:
-		mover := obsmover.ObsMover{}
-		err = mover.DeleteObj(objKey, loca)
-	case flowtype.STOR_TYPE_AZURE_BLOB:
-		mover := blobmover.BlobMover{}
-		err = mover.DeleteObj(objKey, loca)
-	case flowtype.STOR_TYPE_CEPH_S3:
-		mover := cephs3mover.CephS3Mover{}
-		err = mover.DeleteObj(objKey, loca)
-	case flowtype.STOR_TYPE_GCP_S3:
-		mover := Gcps3mover.GcpS3Mover{}
-		err = mover.DeleteObj(objKey, loca)
-	default:
-		logger.Printf("delete object[objkey:%s] from backend storage failed.\n", obj.ObjectKey)
-		err = errors.New(DMERR_UnSupportBackendType)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	//delete metadata
-	if loca.VirBucket != "" {
-		delMetaReq := osdss3.DeleteObjectInput{Bucket: loca.VirBucket, Key: obj.ObjectKey}
-		_, err = s3client.DeleteObject(ctx, &delMetaReq)
-		if err != nil {
-			logger.Printf("delete object metadata of obj[bucket:%s,objKey:%s] failed, err:%v\n", loca.VirBucket,
-				obj.ObjectKey, err)
-		} else {
-			logger.Printf("Delete object metadata of obj[bucket:%s,objKey:%s] successfully.\n", loca.VirBucket,
-				obj.ObjectKey)
-		}
-	}
-
-	return err
-}
-
-func move(ctx context.Context, obj *osdss3.Object, capa chan int64, th chan int, srcLoca *LocationInfo,
-	destLoca *LocationInfo, remainSource bool, locaMap map[string]*LocationInfo, job *flowtype.Job) {
-	logger.Printf("Obj[%s] is stored in the backend is [%s], default backend is [%s], target backend is [%s].\n",
-		obj.ObjectKey, obj.Location, srcLoca.BakendName, destLoca.BakendName)
+func migrate(ctx context.Context, obj *osdss3.Object, capa chan int64, th chan int, req *pb.RunJobRequest, job *flowtype.Job) {
+	log.Infof("Move obj[%s] from bucket[%s] to bucket[%s].\n",
+		obj.ObjectKey, job.SourceLocation, job.DestLocation)
 
 	succeed := true
-	needMove := true
-	newSrcLoca, err := refreshSrcLocation(ctx, obj, srcLoca, destLoca, locaMap)
+
+	// copy object
+	var err error
+	PART_SIZE = GetMultipartSize()
+	destLoc := &LocationInfo{BucketName: req.DestConn.BucketName}
+	if obj.Size <= PART_SIZE {
+		err = CopyObj(ctx, obj, destLoc, job)
+	} else {
+		err = MultipartCopyObj(ctx, obj, destLoc, job)
+	}
+
 	if err != nil {
-		needMove = false
 		succeed = false
 	}
 
-	if needMove {
-		//move object
-		part_size, err := strconv.ParseInt(os.Getenv("PARTSIZE"), 10, 64)
-		logger.Printf("part_size=%d, err=%v.\n", part_size, err)
-		if err == nil {
-			//part_size must be more than 5M and less than 100M
-			if part_size >= 5 && part_size <= 100 {
-				PART_SIZE = part_size * 1024 * 1024
-				logger.Printf("Set PART_SIZE to be %d.\n", PART_SIZE)
-			}
-		}
-		if obj.Size <= PART_SIZE {
-			err = MoveObj(obj, newSrcLoca, destLoca, job)
-		} else {
-			err = MultipartMoveObj(obj, newSrcLoca, destLoca, job)
-		}
-
-		if err != nil {
-			succeed = false
-		}
-	}
-
-	//TODO: what if update metadata failed
-	//add object metadata to the destination bucket if destination is not self-defined
-	if succeed && destLoca.VirBucket != "" {
-		obj.BucketName = destLoca.VirBucket
-		obj.Location = destLoca.BakendName
-		obj.LastModified = time.Now().Unix()
-		/*_, err := s3client.CreateObject(ctx, obj)
-		if err != nil {
-			logger.Printf("add object metadata of obj [objKey:%s] to bucket[name:%s] failed, err:%v.\n", obj.ObjectKey,
-				obj.BucketName, err)
-		} else {
-			logger.Printf("add object metadata of obj [objKey:%s] to bucket[name:%s] succeed.\n", obj.ObjectKey,
-				obj.BucketName)
-		}*/
-	}
-
-	//Delete source data if needed
-	logger.Printf("remainSource for object[%s] is:%v.", obj.ObjectKey, remainSource)
-	if succeed && !remainSource {
-		deleteObj(ctx, obj, newSrcLoca)
-		//TODO: what if delete failed
+	if succeed && !req.RemainSource {
+		deleteObj(ctx, obj)
+		// TODO: Need to clean if delete failed.
 	}
 
 	if succeed {
 		//If migrate success, update capacity
-		logger.Printf("  migrate object[%s] succeed.", obj.ObjectKey)
+		log.Infof("  migrate object[key=%s,versionid=%s] succeed.", obj.ObjectKey, obj.VersionId)
 		capa <- obj.Size
 		if job.Type == "migration" {
 			progress(job, obj.Size, WT_DELETE)
 		}
 	} else {
-		logger.Printf("  migrate object[%s] failed.", obj.ObjectKey)
+		log.Infof("  migrate object[key=%s,versionid=%s] failed.", obj.ObjectKey, obj.VersionId)
 		capa <- -1
 	}
+
 	t := <-th
-	logger.Printf("  migrate: consume %d routine, len(th)=%d\n", t, len(th))
+	log.Infof("  migrate: consume %d routine, len(th)=%d\n", t, len(th))
 }
 
 func updateJob(j *flowtype.Job) {
@@ -540,21 +189,49 @@ func updateJob(j *flowtype.Job) {
 			break
 		}
 		if i == 3 {
-			logger.Printf("update the finish status of job in database failed three times, no need to try more.")
+			log.Infof("update the finish status of job in database failed three times, no need to try more.")
 		}
 	}
 }
 
+func initJob(ctx context.Context, in *pb.RunJobRequest, j *flowtype.Job) error {
+	j.Status = flowtype.JOB_STATUS_RUNNING
+	j.SourceLocation = in.SourceConn.BucketName
+	j.DestLocation = in.DestConn.BucketName
+	j.Type = JobType
+
+	// get total count and total size of objects need to be migrated
+	totalCount, totalSize, err := countObjs(ctx, in)
+	if err != nil || totalCount == 0 {
+		if err != nil {
+			j.Status = flowtype.JOB_STATUS_FAILED
+		} else {
+			j.Status = flowtype.JOB_STATUS_SUCCEED
+		}
+		j.EndTime = time.Now()
+		updateJob(j)
+		log.Infof("err:%v, totalCount=%d\n", err, totalCount)
+		return errors.New("no need move")
+	}
+
+	j.TotalCount = totalCount
+	j.TotalCapacity = totalSize
+	updateJob(j)
+
+	return nil
+}
+
 func runjob(in *pb.RunJobRequest) error {
-	logger.Println("Runjob is called in datamover service.")
-	logger.Printf("Request: %+v\n", in)
+	log.Infoln("Runjob is called in datamover service.")
+	log.Infof("Request: %+v\n", in)
 
 	// set context tiemout
 	ctx := metadata.NewContext(context.Background(), map[string]string{
 		common.CTX_KEY_USER_ID:   in.UserId,
 		common.CTX_KEY_TENANT_ID: in.TenanId,
 	})
-	dur := getCtxTimeout()
+	// 60 means 1 minute, 2592000 means 30 days, 86400 means 1 day
+	dur := GetCtxTimeout("JOB_MAX_RUN_TIME", 60, 2592000, 86400)
 	_, ok := ctx.Deadline()
 	if !ok {
 		ctx, _ = context.WithTimeout(ctx, dur)
@@ -562,37 +239,11 @@ func runjob(in *pb.RunJobRequest) error {
 
 	// init job
 	j := flowtype.Job{Id: bson.ObjectIdHex(in.Id)}
-	j.StartTime = time.Now()
-	j.Status = flowtype.JOB_STATUS_RUNNING
-	j.Type = "migration"
-	updateJob(&j)
-
-	// get location information
-	srcLoca, destLoca, err := getLocationInfo(ctx, &j, in)
+	err := initJob(ctx, in, &j)
 	if err != nil {
-		j.Status = flowtype.JOB_STATUS_FAILED
-		j.EndTime = time.Now()
-		updateJob(&j)
 		return err
 	}
 
-	// get total count and total size of objects need to be migrated
-	totalCount, totalSize, err := countObjs(ctx, in)
-
-	j.TotalCount = totalCount
-	j.TotalCapacity = totalSize
-	if err != nil || totalCount == 0 || totalSize == 0 {
-		if err != nil {
-			j.Status = flowtype.JOB_STATUS_FAILED
-		} else {
-			j.Status = flowtype.JOB_STATUS_SUCCEED
-		}
-		j.EndTime = time.Now()
-		updateJob(&j)
-		return err
-	}
-
-	updateJob(&j)
 	// used to transfer capacity(size) of objects
 	capa := make(chan int64)
 	// concurrent go routines is limited to be simuRoutines
@@ -615,7 +266,9 @@ func runjob(in *pb.RunJobRequest) error {
 		}
 
 		//Do migration for each object.
-		go doMove(ctx, objs, capa, th, srcLoca, destLoca, in.RemainSource, &j)
+		//go doMove(ctx, objs, capa, th, srcLoca, destLoca, in.RemainSource, &j)
+		go doMigrate(ctx, objs, capa, th, in, &j)
+
 		if num < int(limit) {
 			break
 		}
@@ -634,23 +287,20 @@ func runjob(in *pb.RunJobRequest) error {
 					capacity += c
 				}
 
-				var deci int64 = totalObjs / 10
-				if totalObjs < 100 || count == totalObjs || count%deci == 0 {
-					//update database
-					j.PassedCount = (int64(passedCount))
-					j.PassedCapacity = capacity
-					logger.Printf("ObjectMigrated:%d,TotalCapacity:%d Progress:%d\n", j.PassedCount, j.TotalCapacity, j.Progress)
-					db.DbAdapter.UpdateJob(&j)
-				}
+				//update database
+				j.PassedCount = passedCount
+				j.PassedCapacity = capacity
+				log.Infof("ObjectMigrated:%d,TotalCapacity:%d Progress:%d\n", j.PassedCount, j.TotalCapacity, j.Progress)
+				db.DbAdapter.UpdateJob(&j)
 			}
 		case <-time.After(time.Duration(JOB_RUN_TIME_MAX) * time.Second):
 			{
 				tmout = true
-				logger.Println("Timout.")
+				log.Warnln("Timout.")
 			}
 		}
 		if count >= totalObjs || tmout {
-			logger.Printf("break, capacity=%d, timout=%v, count=%d, passed count=%d\n", capacity, tmout, count, passedCount)
+			log.Infof("break, capacity=%d, timout=%v, count=%d, passed count=%d\n", capacity, tmout, count, passedCount)
 			close(capa)
 			close(th)
 			break
@@ -661,7 +311,7 @@ func runjob(in *pb.RunJobRequest) error {
 	j.PassedCount = int64(passedCount)
 	if passedCount < totalObjs {
 		errmsg := strconv.FormatInt(totalObjs, 10) + " objects, passed " + strconv.FormatInt(passedCount, 10)
-		logger.Printf("run job failed: %s\n", errmsg)
+		log.Infof("run job failed: %s\n", errmsg)
 		ret = errors.New("failed")
 		j.Status = flowtype.JOB_STATUS_FAILED
 	} else {
@@ -675,7 +325,7 @@ func runjob(in *pb.RunJobRequest) error {
 			break
 		}
 		if i == 3 {
-			logger.Printf("update the finish status of job in database failed three times, no need to try more.")
+			log.Infof("update the finish status of job in database failed three times, no need to try more.")
 		}
 	}
 
@@ -689,6 +339,6 @@ func progress(job *flowtype.Job, size int64, wt float64) {
 	job.MigratedCapacity = math.Round(MigratedCapacity*100) / 100
 	// Progress = Migrated Capacity*100/ Total Capacity
 	job.Progress = int64(job.MigratedCapacity * 100 / float64(job.TotalCapacity))
-	logger.Printf("[INFO] Progress %d", job.Progress)
+	log.Debugf("Progress %d, MigratedCapacity %d, TotalCapacity %d\n", job.Progress, job.MigratedCapacity, job.TotalCapacity)
 	db.DbAdapter.UpdateJob(job)
 }

--- a/datamover/pkg/drivers/https/prepare.go
+++ b/datamover/pkg/drivers/https/prepare.go
@@ -9,128 +9,29 @@ import (
 	"time"
 
 	flowtype "github.com/opensds/multi-cloud/dataflow/pkg/model"
-	"github.com/opensds/multi-cloud/datamover/pkg/db"
 	. "github.com/opensds/multi-cloud/datamover/pkg/utils"
 	pb "github.com/opensds/multi-cloud/datamover/proto"
 	osdss3 "github.com/opensds/multi-cloud/s3/proto"
 	log "github.com/sirupsen/logrus"
 )
 
-func getCtxTimeout() time.Duration {
-	// 1 day as default
-	tmout := 86400 * time.Second
+func GetCtxTimeout(key string, min, max, def int64) time.Duration {
+	// default value
+	tmout := time.Duration(def) * time.Second
 
-	tmoutCfg, err := strconv.ParseInt(os.Getenv("JOB_MAX_RUN_TIME"), 10, 64)
-	if err != nil || tmoutCfg < 60 || tmoutCfg > 2592000 {
+	tmoutCfg, err := strconv.ParseInt(os.Getenv(key), 10, 64)
+	if err != nil || tmoutCfg < min || tmoutCfg > max {
 		tmoutCfg = int64(JOB_RUN_TIME_MAX)
 	}
 	durStr := fmt.Sprintf("%ds", tmoutCfg)
-	logger.Printf("Vaule of JOB_MAX_RUN_TIME is: %d seconds, durStr:%s.\n", tmoutCfg, durStr)
+	log.Debugf("Vaule of %s is: %d seconds, durStr:%s.\n", key, tmoutCfg, durStr)
 	val, err := time.ParseDuration(durStr)
 	if err == nil {
 		tmout = val
 	}
 
-	logger.Printf("tmout=%v\n", tmout)
+	log.Infof("tmout=%v\n", tmout)
 	return tmout
-}
-
-func getLocationInfo(ctx context.Context, j *flowtype.Job, in *pb.RunJobRequest) (srcLoca *LocationInfo, destLoca *LocationInfo, err error) {
-	srcLoca, err = getConnLocation(ctx, in.SourceConn)
-	if err != nil {
-		logger.Printf("err:%v\n", err)
-		return nil, nil, err
-	}
-	logger.Printf("srcLoca:StorType=%s,VirBucket=%s,BucketName=%s,Region=%s\n",
-		srcLoca.StorType, srcLoca.VirBucket, srcLoca.BucketName, srcLoca.Region)
-	destLoca, err = getConnLocation(ctx, in.DestConn)
-	if err != nil {
-		db.DbAdapter.UpdateJob(j)
-		return nil, nil, err
-	}
-	logger.Printf("destLoca:srcLoca:StorType=%s,VirBucket=%s,BucketName=%s,Region=%s\n",
-		destLoca.StorType, destLoca.VirBucket, destLoca.BucketName, destLoca.Region)
-	logger.Println("Get location information successfully.")
-
-	return srcLoca, destLoca, err
-}
-
-func refreshSrcLocation(ctx context.Context, obj *osdss3.Object, srcLoca *LocationInfo, destLoca *LocationInfo,
-	locMap map[string]*LocationInfo) (newSrcLoca *LocationInfo, err error) {
-	if obj.Location != srcLoca.BakendName && obj.Location != "" {
-		//If oject does not use the default backend
-		logger.Printf("locaMap:%+v\n", locMap)
-		//for selfdefined connector, obj.Location and srcLoca.backendname would be ""
-		//TODO: use read/wirte lock
-		newLoc, exists := locMap[obj.Location]
-		if !exists {
-			newLoc, err = getOsdsLocation(ctx, obj.BucketName, obj.Location)
-			if err != nil {
-				return nil, err
-			}
-		}
-		locMap[obj.Location] = newLoc
-		logger.Printf("newSrcLoca=%+v\n", newLoc)
-		return newLoc, nil
-	}
-
-	return srcLoca, nil
-}
-
-func getOsdsLocation(ctx context.Context, virtBkname string, backendName string) (*LocationInfo, error) {
-	if backendName == "" {
-		logger.Println("get backend location failed, because backend name is null.")
-		return nil, errors.New("failed")
-	}
-
-	bk, err := db.DbAdapter.GetBackendByName(backendName)
-	if err != nil {
-		logger.Printf("get backend information failed, err:%v\n", err)
-		return nil, errors.New("failed")
-	} else {
-		loca := &LocationInfo{StorType: bk.Type, Region: bk.Region, EndPoint: bk.Endpoint, BucketName: bk.BucketName,
-			VirBucket: virtBkname, Access: bk.Access, Security: bk.Security, BakendName: backendName}
-		logger.Printf("Refresh backend[name:%s,id:%s] successfully.\n", backendName, bk.Id.String())
-		return loca, nil
-	}
-}
-
-func getConnLocation(ctx context.Context, conn *pb.Connector) (*LocationInfo, error) {
-	switch conn.Type {
-	case flowtype.STOR_TYPE_OPENSDS:
-		virtBkname := conn.GetBucketName()
-		rspbk, err := s3client.GetBucket(ctx, &osdss3.Bucket{Name: virtBkname})
-		if err != nil {
-			logger.Printf("get bucket[%s] information failed when refresh connector location, err:%v\n", virtBkname, err)
-			return nil, errors.New("get bucket information failed")
-		}
-		return getOsdsLocation(ctx, virtBkname, rspbk.BucketMeta.DefaultLocation)
-	case flowtype.STOR_TYPE_AWS_S3, flowtype.STOR_TYPE_HW_OBS, flowtype.STOR_TYPE_HW_FUSIONSTORAGE, flowtype.STOR_TYPE_AZURE_BLOB, flowtype.STOR_TYPE_CEPH_S3, flowtype.STOR_TYPE_GCP_S3, flowtype.STOR_TYPE_IBM_COS:
-		cfg := conn.ConnConfig
-		loca := LocationInfo{}
-		loca.StorType = conn.Type
-		for i := 0; i < len(cfg); i++ {
-			switch cfg[i].Key {
-			case "region":
-				loca.Region = cfg[i].Value
-			case "endpoint":
-				loca.EndPoint = cfg[i].Value
-			case "bucketname":
-				loca.BucketName = cfg[i].Value
-			case "access":
-				loca.Access = cfg[i].Value
-			case "security":
-				loca.Security = cfg[i].Value
-			default:
-				logger.Printf("unknow key[%s] for connector.\n", cfg[i].Key)
-			}
-		}
-		return &loca, nil
-	default:
-		logger.Printf("unsupport type:%s.\n", conn.Type)
-	}
-
-	return nil, errors.New("unsupport type")
 }
 
 func getObjs(ctx context.Context, in *pb.RunJobRequest, marker string, limit int32) ([]*osdss3.Object, error) {
@@ -138,14 +39,14 @@ func getObjs(ctx context.Context, in *pb.RunJobRequest, marker string, limit int
 	case flowtype.STOR_TYPE_OPENSDS:
 		return getOsdsS3Objs(ctx, in, marker, limit)
 	default:
-		logger.Printf("unsupport storage type:%v\n", in.SourceConn.Type)
+		log.Errorf("unsupport storage type:%v\n", in.SourceConn.Type)
 	}
 
 	return nil, errors.New(DMERR_InternalError)
 }
 
 func countOsdsS3Objs(ctx context.Context, in *pb.RunJobRequest) (count, size int64, err error) {
-	logger.Printf("count objects of bucket[%s].\n", in.SourceConn.BucketName)
+	log.Debugf("count objects of bucket[%s].\n", in.SourceConn.BucketName)
 
 	req := osdss3.ListObjectsRequest{Bucket: in.SourceConn.BucketName}
 	if in.GetFilt() != nil && len(in.Filt.Prefix) > 0 {
@@ -154,11 +55,11 @@ func countOsdsS3Objs(ctx context.Context, in *pb.RunJobRequest) (count, size int
 
 	rsp, err := s3client.CountObjects(ctx, &req)
 	if err != nil {
-		logger.Printf("err: %v\n", err)
+		log.Errorf("err: %v\n", err)
 		return 0, 0, errors.New(DMERR_InternalError)
 	}
 
-	logger.Printf("count objects of bucket[%s]: count=%d,size=%d\n", in.SourceConn.BucketName, rsp.Count, rsp.Size)
+	log.Debugf("count objects of bucket[%s]: count=%d,size=%d\n", in.SourceConn.BucketName, rsp.Count, rsp.Size)
 	return rsp.Count, rsp.Size, nil
 }
 
@@ -167,14 +68,14 @@ func countObjs(ctx context.Context, in *pb.RunJobRequest) (count, size int64, er
 	case flowtype.STOR_TYPE_OPENSDS:
 		return countOsdsS3Objs(ctx, in)
 	default:
-		logger.Printf("unsupport storage type:%v\n", in.SourceConn.Type)
+		log.Errorf("unsupport storage type:%v\n", in.SourceConn.Type)
 	}
 
 	return 0, 0, errors.New(DMERR_UnSupportBackendType)
 }
 
 func getOsdsS3Objs(ctx context.Context, in *pb.RunJobRequest, marker string, limit int32) ([]*osdss3.Object, error) {
-	logger.Println("get osds objects begin")
+	log.Debugf("get osds objects begin")
 
 	req := osdss3.ListObjectsRequest{
 		Bucket:  in.SourceConn.BucketName,
@@ -186,12 +87,12 @@ func getOsdsS3Objs(ctx context.Context, in *pb.RunJobRequest, marker string, lim
 	}
 	rsp, err := s3client.ListObjects(ctx, &req)
 	if err != nil {
-		logger.Printf("list objects failed, bucket=%s, marker=%s, limit=%d, err:%v\n",
+		log.Errorf("list objects failed, bucket=%s, marker=%s, limit=%d, err:%v\n",
 			in.SourceConn.BucketName, marker, limit, err)
 		return nil, err
 	}
 
-	logger.Println("get osds objects successfully")
+	log.Debugf("get osds objects successfully")
 	return rsp.Objects, nil
 }
 

--- a/datamover/pkg/drivers/lifecycle/expiration.go
+++ b/datamover/pkg/drivers/lifecycle/expiration.go
@@ -41,7 +41,8 @@ func doExpirationAction(acReq *datamover.LifecycleActionRequest) error {
 
 	// call API of s3 service to delete object
 	delMetaReq := osdss3.DeleteObjectInput{Bucket: bucketName, Key: objKey, VersioId: versionId}
-	ctx, _ := context.WithTimeout(context.Background(), CLOUD_OPR_TIMEOUT*time.Second)
+	// as expiration does not need to move data, so it's timeout time is not need to be too large.
+	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
 	ctx = metadata.NewContext(ctx, map[string]string{common.CTX_KEY_IS_ADMIN: strconv.FormatBool(true)})
 	_, err := s3client.DeleteObject(ctx, &delMetaReq)
 	if err != nil {

--- a/datamover/pkg/drivers/lifecycle/lifecycle.go
+++ b/datamover/pkg/drivers/lifecycle/lifecycle.go
@@ -29,13 +29,14 @@ var s3client osdss3.S3Service
 var bkendclient backend.BackendService
 var mutex sync.RWMutex
 
+const SECONDS_ONE_MINUTE = 60
+const SECONDS_30_DAYS = 2592000
+const SECONDS_ONE_HOUR = 3600
+
 type Int2String map[int32]string
 
 // map from cloud vendor name to it's map relation relationship between internal tier to it's storage class name.
 var Int2ExtTierMap map[string]*Int2String
-
-// TODO: do more test to choose the best value
-const CLOUD_OPR_TIMEOUT = 86400 // seconds
 
 func Init() {
 	log.Infof("Lifecycle datamover init.")

--- a/datamover/pkg/utils/data_type.go
+++ b/datamover/pkg/utils/data_type.go
@@ -15,13 +15,7 @@
 package utils
 
 type LocationInfo struct {
-	StorType   string //aws-s3,azure-blob,hw-obs,ceph-s3 etc.
-	Region     string
-	EndPoint   string
-	BucketName string //remote bucket name
-	VirBucket  string //local bucket name
-	Access     string
-	Security   string
+	BucketName string // bucket name
 	BakendName string
 	ClassName  string
 	Tier       int32

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,10 +103,13 @@ services:
       - MICRO_REGISTRY=mdns
       - DB_HOST=datastore:27017
       - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
-      #PARTSIZE for multi-part migration, should not be less than 5(MB) or more than 100(MB)
+      # PARTSIZE for multi-part migration, should not be less than 5(MB) or more than 100(MB)
       - PARTSIZE=16
-      #JOB_MAX_RUN_TIME for each migration job, should not be less than 60(second) or more than 2592000(second)
+      # JOB_MAX_RUN_TIME for each migration job, should not be less than 60(seconds) or more than 2592000(seconds)
       - JOB_MAX_RUN_TIME=86400
+      # For lifecycle, if object need to be moved from one place to another, how long this moving can continue, should
+      # not be less than 60(seconds) or more than 2592000(seconds).
+      - OBJECT_MOVE_TIME=3600
     depends_on:
       - zookeeper
       - kafka

--- a/s3/pkg/service/object.go
+++ b/s3/pkg/service/object.go
@@ -513,6 +513,8 @@ func (s *s3Service) CopyObject(ctx context.Context, in *pb.CopyObjectRequest, ou
 	targetObject.StorageMeta = res.Meta
 	targetObject.Location = targetBackendName
 	targetObject.TenantId = tenantid
+	// we only support copy data with sse but not support copy data without sse right now
+	targetObject.ServerSideEncryption = srcObject.ServerSideEncryption
 	// TODO: delete old object
 
 	err = s.MetaStorage.PutObject(ctx, &meta.Object{Object: targetObject}, nil, nil, true)

--- a/s3/pkg/service/object.go
+++ b/s3/pkg/service/object.go
@@ -439,7 +439,7 @@ func (s *s3Service) CopyObject(ctx context.Context, in *pb.CopyObjectRequest, ou
 		log.Errorln("failed to get object info from meta storage. err:", err)
 		return err
 	}
-	_, _, err = CheckRights(ctx, srcObject.TenantId)
+	_, tenantid, err := CheckRights(ctx, srcObject.TenantId)
 	if err != nil {
 		log.Errorf("no rights to access the source object[%s]\n", srcObject.ObjectKey)
 		return nil
@@ -465,7 +465,8 @@ func (s *s3Service) CopyObject(ctx context.Context, in *pb.CopyObjectRequest, ou
 		log.Errorln("get bucket failed with err:", err)
 		return err
 	}
-	targetBackend, err := utils.GetBackend(ctx, s.backendClient, targetBucket.DefaultLocation)
+	targetBackendName := targetBucket.DefaultLocation
+	targetBackend, err := utils.GetBackend(ctx, s.backendClient, targetBackendName)
 	if err != nil {
 		log.Errorln("failed to get backend client with err:", err)
 		return err
@@ -510,7 +511,8 @@ func (s *s3Service) CopyObject(ctx context.Context, in *pb.CopyObjectRequest, ou
 	targetObject.CustomAttributes = srcObject.CustomAttributes
 	targetObject.Type = meta.ObjectTypeNormal
 	targetObject.StorageMeta = res.Meta
-
+	targetObject.Location = targetBackendName
+	targetObject.TenantId = tenantid
 	// TODO: delete old object
 
 	err = s.MetaStorage.PutObject(ctx, &meta.Object{Object: targetObject}, nil, nil, true)
@@ -945,7 +947,7 @@ func (s *s3Service) ListObjects(ctx context.Context, in *pb.ListObjectsRequest, 
 		}
 		object.StorageClass, _ = GetNameFromTier(obj.Tier, utils.OSTYPE_OPENSDS)
 		objects = append(objects, &object)
-		log.Infof("object:%+v\n", object)
+		log.Debugf("object:%+v\n", object)
 	}
 	out.Objects = objects
 	out.Prefixes = appendInfo.Prefixes


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR refactored migration function based on the CopyObject API provided OSDS S3 service, that means datamover do not need to migrate data by itself, then we do not need to maintain two copies of code for the same function. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
As those codes before used for migration data in datamover are removed, the progress update also need to do some change, so @Click2Cloud-Gamma please review the part about progress update.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
With this PR, objects less than PARTSIZE(16M as default) can be migrated, while objects bigger than this size can not be migrated, for those bigger objects, the next PR will provide the migration ability.
```
