### PR TITLE
fix the problem of yig crash when s3 stops.

### DIFF
--- a/s3/pkg/datastore/yig/factory.go
+++ b/s3/pkg/datastore/yig/factory.go
@@ -93,7 +93,9 @@ func (ydf *YigDriverFactory) Init() error {
 func (ydf *YigDriverFactory) Close() {
 	var keys []interface{}
 	// stop config watcher
-	ydf.cfgWatcher.Stop()
+	if ydf.cfgWatcher != nil {
+		ydf.cfgWatcher.Stop()
+	}
 	// close the drivers
 	ydf.Drivers.Range(func(k, v interface{}) bool {
 		drv := v.(*storage.YigStorage)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR fixes the problem of throwing yig backend exception when s3 stops.
The reason is that yig backend may not be initialized during s3 starts, when s3 stops, cfgWatcher of yig should be checked before calling its stop method.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
