### PR TITLE
fix issue#841

### DIFF
--- a/api/pkg/s3/bucketdelete.go
+++ b/api/pkg/s3/bucketdelete.go
@@ -28,7 +28,7 @@ func (s *APIService) BucketDelete(request *restful.Request, response *restful.Re
 	ctx := common.InitCtxWithAuthInfo(request)
 	rsp, err := s.s3Client.DeleteBucket(ctx, &s3.Bucket{Name: bucketName})
 	if HandleS3Error(response, request, err, rsp.GetErrorCode()) != nil {
-		log.Errorf("delete bucket[%s] failed, err=%v, errCode=%d\n", bucketName, err, rsp.ErrorCode)
+		log.Errorf("delete bucket[%s] failed, err=%v, errCode=%d\n", bucketName, err, rsp.GetErrorCode())
 		return
 	}
 

--- a/api/pkg/s3/bucketget.go
+++ b/api/pkg/s3/bucketget.go
@@ -46,7 +46,7 @@ func (s *APIService) BucketGet(request *restful.Request, response *restful.Respo
 	ctx := common.InitCtxWithAuthInfo(request)
 	lsRsp, err := s.s3Client.ListObjects(ctx, &req)
 	if HandleS3Error(response, request, err, lsRsp.GetErrorCode()) != nil {
-		log.Errorf("get bucket[%s] failed, err=%v, errCode=%d\n", bucketName, err, lsRsp.ErrorCode)
+		log.Errorf("get bucket[%s] failed, err=%v, errCode=%d\n", bucketName, err, lsRsp.GetErrorCode())
 		return
 	}
 

--- a/api/pkg/s3/bucketlifecycledelete.go
+++ b/api/pkg/s3/bucketlifecycledelete.go
@@ -29,7 +29,7 @@ func (s *APIService) BucketLifecycleDelete(request *restful.Request, response *r
 	rsp, err := s.s3Client.DeleteBucketLifecycle(ctx, &s3.BaseRequest{Id: bucketName})
 	log.Infof("rsp:%s, err:%v\n", rsp, err)
 	if HandleS3Error(response, request, err, rsp.GetErrorCode()) != nil {
-		log.Errorf("delete bucket[%s] lifecycle failed, err=%v, errCode=%d\n", bucketName, err, rsp.ErrorCode)
+		log.Errorf("delete bucket[%s] lifecycle failed, err=%v, errCode=%d\n", bucketName, err, rsp.GetErrorCode())
 		return
 	}
 

--- a/api/pkg/s3/bucketlifecycleget.go
+++ b/api/pkg/s3/bucketlifecycleget.go
@@ -59,7 +59,7 @@ func (s *APIService) BucketLifecycleGet(request *restful.Request, response *rest
 	ctx := common.InitCtxWithAuthInfo(request)
 	rsp, err := s.s3Client.GetBucketLifecycle(ctx, &s3.BaseRequest{Id: bucketName})
 	if HandleS3Error(response, request, err, rsp.GetErrorCode()) != nil {
-		log.Errorf("get bucket[%s] lifecycle failed, err=%v, errCode=%d\n", bucketName, err, rsp.ErrorCode)
+		log.Errorf("get bucket[%s] lifecycle failed, err=%v, errCode=%d\n", bucketName, err, rsp.GetErrorCode())
 		return
 	}
 

--- a/api/pkg/s3/bucketlifecycleput.go
+++ b/api/pkg/s3/bucketlifecycleput.go
@@ -225,7 +225,7 @@ func (s *APIService) BucketLifecyclePut(request *restful.Request, response *rest
 
 	lcRsp, err := s.s3Client.PutBucketLifecycle(ctx, &s3.PutBucketLifecycleRequest{BucketName: bucketName, Lc: s3RulePtrArr})
 	if HandleS3Error(response, request, err, lcRsp.GetErrorCode()) != nil {
-		log.Errorf("put bucket[%s] lifecycle failed, err=%v, errCode=%d\n", bucketName, err, lcRsp.ErrorCode)
+		log.Errorf("put bucket[%s] lifecycle failed, err=%v, errCode=%d\n", bucketName, err, lcRsp.GetErrorCode())
 		return
 	}
 

--- a/api/pkg/s3/bucketput.go
+++ b/api/pkg/s3/bucketput.go
@@ -90,7 +90,7 @@ func (s *APIService) BucketPut(request *restful.Request, response *restful.Respo
 
 	rsp, err := s.s3Client.CreateBucket(ctx, &bucket)
 	if HandleS3Error(response, request, err, rsp.GetErrorCode()) != nil {
-		log.Errorf("delete bucket[%s] failed, err=%v, errCode=%d\n", bucketName, err, rsp.ErrorCode)
+		log.Errorf("delete bucket[%s] failed, err=%v, errCode=%d\n", bucketName, err, rsp.GetErrorCode())
 		return
 	}
 

--- a/api/pkg/s3/objectdelete.go
+++ b/api/pkg/s3/objectdelete.go
@@ -50,7 +50,7 @@ func (s *APIService) ObjectDelete(request *restful.Request, response *restful.Re
 	ctx := common.InitCtxWithAuthInfo(request)
 	rsp, err := s.s3Client.DeleteObject(ctx, &input)
 	if HandleS3Error(response, request, err, rsp.GetErrorCode()) != nil {
-		log.Errorf("delete object[%s] failed, err=%v, errCode=%d\n", objectName, err, rsp.ErrorCode)
+		log.Errorf("delete object[%s] failed, err=%v, errCode=%d\n", objectName, err, rsp.GetErrorCode())
 		return
 	}
 

--- a/api/pkg/s3/objectget.go
+++ b/api/pkg/s3/objectget.go
@@ -146,9 +146,9 @@ func (s *APIService) ObjectGet(request *restful.Request, response *restful.Respo
 			eof = true
 		}
 		// It indicate that there is a error from grpc server.
-		if rsp.ErrorCode != int32(s3error.ErrNoErr) {
-			s3err = rsp.ErrorCode
-			log.Errorf("received s3 service error, error code:%v", rsp.ErrorCode)
+		if rsp.GetErrorCode() != int32(s3error.ErrNoErr) {
+			s3err = rsp.GetErrorCode()
+			log.Errorf("received s3 service error, error code:%v", s3err)
 			break
 		}
 		// If there is no data in rsp.Data, it show that there is no more data to receive

--- a/api/pkg/s3/service.go
+++ b/api/pkg/s3/service.go
@@ -79,8 +79,8 @@ func (s *APIService) getBucketMeta(ctx context.Context, bucketName string) (*s3.
 	// gRPC client, so in our codes, gRPC server will return nil and set error code to reponse package while business
 	// error happens, and if gRPC client received error, that means some exception happened for gRPC itself.
 	if err == nil {
-		if rsp.ErrorCode != int32(ErrNoErr) {
-			err = S3ErrorCode(rsp.ErrorCode)
+		if rsp.GetErrorCode() != int32(ErrNoErr) {
+			err = S3ErrorCode(rsp.GetErrorCode())
 		}
 	}
 	if err != nil {
@@ -97,8 +97,8 @@ func (s *APIService) getObjectMeta(ctx context.Context, bucketName, objectName, 
 	// gRPC client, so in our codes, gRPC server will return nil and set error code to reponse package while business
 	// error happens, and if gRPC client received error, that means some exception happened for gRPC itself.
 	if err == nil {
-		if rsp.ErrorCode != int32(ErrNoErr) {
-			err = S3ErrorCode(rsp.ErrorCode)
+		if rsp.GetErrorCode() != int32(ErrNoErr) {
+			err = S3ErrorCode(rsp.GetErrorCode())
 		}
 	}
 	if err != nil {

--- a/dataflow/pkg/scheduler/lifecycle/lifecycle_sched.go
+++ b/dataflow/pkg/scheduler/lifecycle/lifecycle_sched.go
@@ -225,7 +225,7 @@ func getObjects(r *InternalLifecycleRule, marker string, limit int32) ([]*osdss3
 	ctx := metadata.NewContext(context.Background(), map[string]string{common.CTX_KEY_IS_ADMIN: strconv.FormatBool(true)})
 	log.Debugf("ListObjectsRequest:%+v\n", s3req)
 	s3rsp, err := s3client.ListObjects(ctx, &s3req)
-	if err != nil || s3rsp.ErrorCode != int32(s3error.ErrNoErr) {
+	if err != nil || s3rsp.GetErrorCode() != int32(s3error.ErrNoErr) {
 		log.Errorf("list objects failed, req:%+v,  err:%v.\n", s3req, err)
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When grpc server return error to grpc client, grpc client cannot get a response package except error, so the client cannot use the response package directly, otherwise, grpc client will crash. In this PR, we will make sure grpc client doesn't use response directly but check if it is null before using it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #841 

**Special notes for your reviewer**:
Currently, if grpc server, like osds s3 service, want to return a business error to the grpc client, the grpc server need to return nil and a response package, but not error.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
