### PR TITLE
fix acl bug, that is others cannot put/get/delete objects even if pub…

### DIFF
--- a/api/pkg/common/common.go
+++ b/api/pkg/common/common.go
@@ -53,6 +53,7 @@ const (
 	CTX_KEY_USER_ID     = "Userid"
 	CTX_KEY_IS_ADMIN    = "Isadmin"
 	CTX_VAL_TRUE        = "true"
+	CTX_REPRE_TENANT    = "Representedtenantid"
 	CTX_KEY_OBJECT_KEY  = "ObjectKey"
 	CTX_KEY_BUCKET_NAME = "BucketName"
 	CTX_KEY_SIZE        = "ObjectSize"

--- a/backend/pkg/db/drivers/mongo/mongo.go
+++ b/backend/pkg/db/drivers/mongo/mongo.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
-	log "github.com/sirupsen/logrus"
 	"github.com/micro/go-micro/metadata"
 	"github.com/opensds/multi-cloud/api/pkg/common"
 	"github.com/opensds/multi-cloud/backend/pkg/model"
+	log "github.com/sirupsen/logrus"
 )
 
 type mongoRepository struct {
@@ -72,11 +72,15 @@ func UpdateContextFilter(ctx context.Context, m bson.M) error {
 
 	isAdmin, _ := md[common.CTX_KEY_IS_ADMIN]
 	if isAdmin != common.CTX_VAL_TRUE {
-		tenantId, ok := md[common.CTX_KEY_TENANT_ID]
-		if !ok {
-			log.Error("get tenantid failed")
-			return errors.New("get tenantid failed")
+		tenantId, _ := md[common.CTX_REPRE_TENANT]
+		if tenantId == "" {
+			tenantId, ok = md[common.CTX_KEY_TENANT_ID]
+			if !ok {
+				log.Error("get tenantid failed")
+				return errors.New("get tenantid failed")
+			}
 		}
+
 		m["tenantId"] = tenantId
 	}
 

--- a/s3/pkg/service/multipart.go
+++ b/s3/pkg/service/multipart.go
@@ -129,6 +129,8 @@ func (s *s3Service) InitMultipartUpload(ctx context.Context, in *pb.InitMultiPar
 	if backendName == "" {
 		backendName = bucket.DefaultLocation
 	}
+	// incase get backend failed
+	ctx = utils.SetRepresentTenant(ctx, tenantId, bucket.TenantId)
 	backend, err := utils.GetBackend(ctx, s.backendClient, backendName)
 	if err != nil {
 		log.Errorln("failed to get backend client with err:", err)
@@ -247,6 +249,8 @@ func (s *s3Service) UploadPart(ctx context.Context, stream pb.S3_UploadPartStrea
 	}
 
 	backendName := bucket.DefaultLocation
+	// incase get backend failed
+	ctx = utils.SetRepresentTenant(ctx, tenantId, bucket.TenantId)
 	backend, err := utils.GetBackend(ctx, s.backendClient, backendName)
 	if err != nil {
 		log.Errorln("failed to get backend client with err:", err)
@@ -376,6 +380,8 @@ func (s *s3Service) CompleteMultipartUpload(ctx context.Context, in *pb.Complete
 	eTag += "-" + strconv.Itoa(len(in.CompleteParts))
 
 	backendName := bucket.DefaultLocation
+	// incase get backend failed
+	ctx = utils.SetRepresentTenant(ctx, tenantId, bucket.TenantId)
 	backend, err := utils.GetBackend(ctx, s.backendClient, backendName)
 	if err != nil {
 		log.Errorln("failed to get backend client with err:", err)
@@ -501,6 +507,8 @@ func (s *s3Service) AbortMultipartUpload(ctx context.Context, in *pb.AbortMultip
 	}
 
 	backendName := bucket.DefaultLocation
+	// incase get backend failed
+	ctx = utils.SetRepresentTenant(ctx, tenantId, bucket.TenantId)
 	backend, err := utils.GetBackend(ctx, s.backendClient, backendName)
 	if err != nil {
 		log.Errorln("failed to get backend client with err:", err)
@@ -678,6 +686,8 @@ func (s *s3Service) CopyObjPart(ctx context.Context, in *pb.CopyObjPartRequest, 
 	if in.TargetLocation != "" {
 		targetBackendName = in.TargetLocation
 	}
+	// incase get backend failed
+	ctx = utils.SetRepresentTenant(ctx, tenantId, targetBucket.TenantId)
 	targetBackend, err := utils.GetBackend(ctx, s.backendClient, targetBackendName)
 	if err != nil {
 		log.Errorln("failed to get backend client with err:", err)

--- a/s3/pkg/service/object.go
+++ b/s3/pkg/service/object.go
@@ -177,6 +177,8 @@ func (s *s3Service) PutObject(ctx context.Context, in pb.S3_PutObjectStream) err
 	if req.Location != "" {
 		backendName = req.Location
 	}
+	// incase get backend failed
+	ctx = utils.SetRepresentTenant(ctx, tenantId, bucket.TenantId)
 	backend, err := utils.GetBackend(ctx, s.backendClient, backendName)
 	if err != nil {
 		log.Errorln("failed to get backend client with err:", err)
@@ -185,7 +187,6 @@ func (s *s3Service) PutObject(ctx context.Context, in pb.S3_PutObjectStream) err
 
 	log.Infoln("bucket location:", req.Location, " backendtype:", backend.Type, " endpoint:", backend.Endpoint)
 	bodyMd5 := req.Attrs["md5Sum"]
-	ctx = context.Background()
 	ctx = context.WithValue(ctx, dscommon.CONTEXT_KEY_SIZE, req.Size)
 	ctx = context.WithValue(ctx, dscommon.CONTEXT_KEY_MD5, bodyMd5)
 	sd, err := driver.CreateStorageDriver(backend.Type, backend)
@@ -330,6 +331,8 @@ func (s *s3Service) GetObject(ctx context.Context, req *pb.GetObjectInput, strea
 	if object.Location != "" {
 		backendName = object.Location
 	}
+	// incase get backend failed
+	ctx = utils.SetRepresentTenant(ctx, tenantId, bucket.TenantId)
 	// if this object has only one part
 	backend, err := utils.GetBackend(ctx, s.backendClient, backendName)
 	if err != nil {
@@ -484,6 +487,8 @@ func (s *s3Service) CopyObject(ctx context.Context, in *pb.CopyObjectRequest, ou
 	if srcObject.Location != "" {
 		backendName = srcObject.Location
 	}
+	// incase get backend failed
+	ctx = utils.SetRepresentTenant(ctx, tenantId, srcBucket.TenantId)
 	srcBackend, err := utils.GetBackend(ctx, s.backendClient, backendName)
 	if err != nil {
 		log.Errorln("failed to get backend client with err:", err)
@@ -496,6 +501,8 @@ func (s *s3Service) CopyObject(ctx context.Context, in *pb.CopyObjectRequest, ou
 	}
 
 	targetBackendName := targetBucket.DefaultLocation
+	// incase get backend failed
+	ctx = utils.SetRepresentTenant(ctx, tenantId, targetBucket.TenantId)
 	targetBackend, err := utils.GetBackend(ctx, s.backendClient, targetBackendName)
 	if err != nil {
 		log.Errorln("failed to get backend client with err:", err)
@@ -827,7 +834,7 @@ func (s *s3Service) DeleteObject(ctx context.Context, in *pb.DeleteObjectInput, 
 	object, err := s.MetaStorage.GetObject(ctx, in.Bucket, in.Key, in.VersioId, true)
 	if err != nil {
 		log.Errorln("failed to get object info from meta storage. err:", err)
-		return err
+		return nil
 	}
 	isAdmin, tenantId, _, err := CheckRights(ctx, object.TenantId)
 	if err != nil {
@@ -851,7 +858,7 @@ func (s *s3Service) DeleteObject(ctx context.Context, in *pb.DeleteObjectInput, 
 
 	switch bucket.Versioning.Status {
 	case utils.VersioningDisabled:
-		err = s.removeObject(ctx, bucket, object)
+		err = s.removeObject(ctx, bucket, object, tenantId)
 	case utils.VersioningEnabled:
 		// TODO: versioning
 		err = ErrInternalError
@@ -868,7 +875,7 @@ func (s *s3Service) DeleteObject(ctx context.Context, in *pb.DeleteObjectInput, 
 	return nil
 }
 
-func (s *s3Service) removeObject(ctx context.Context, bucket *meta.Bucket, obj *Object) error {
+func (s *s3Service) removeObject(ctx context.Context, bucket *meta.Bucket, obj *Object, requestTenant string) error {
 	if obj == nil {
 		log.Infof("no need remove")
 		return nil
@@ -878,6 +885,8 @@ func (s *s3Service) removeObject(ctx context.Context, bucket *meta.Bucket, obj *
 	if obj.Location != "" {
 		backendName = obj.Location
 	}
+	// incase get backend failed
+	ctx = utils.SetRepresentTenant(ctx, requestTenant, bucket.TenantId)
 	backend, err := utils.GetBackend(ctx, s.backendClient, backendName)
 	if err != nil {
 		log.Errorln("failed to get backend with err:", err)

--- a/s3/pkg/utils/utils.go
+++ b/s3/pkg/utils/utils.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
+	"github.com/micro/go-micro/metadata"
+	"github.com/opensds/multi-cloud/api/pkg/common"
 	"github.com/opensds/multi-cloud/backend/proto"
 	log "github.com/sirupsen/logrus"
 )
@@ -137,4 +139,14 @@ func GetBackend(ctx context.Context, backedClient backend.BackendService, backen
 	log.Infof("backendRep is %v:", backendRep)
 	backend := backendRep.Backends[0]
 	return backend, nil
+}
+
+func SetRepresentTenant(ctx context.Context, requestTenant, sourceTenant string) context.Context {
+	if requestTenant != sourceTenant {
+		md, _ := metadata.FromContext(ctx)
+		md[common.CTX_REPRE_TENANT] = sourceTenant
+		ctx = metadata.NewContext(ctx, md)
+	}
+
+	return ctx
 }


### PR DESCRIPTION
…lic-read-write is set

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is used to fix the bug that others cannot put/get/delete objects even if the ACL of bucket is set to be public-read-write.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #847 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Test report as below:
1. Set ACL:
![set_acl](https://user-images.githubusercontent.com/38932432/71574061-f9052300-2b21-11ea-80f8-12f757026921.jpg)
2. Login with another tenant and put object:
![put_obj](https://user-images.githubusercontent.com/38932432/71574082-16d28800-2b22-11ea-88fe-8a9e591fd79b.jpg)
3. Copy object:
![copy_obj_1](https://user-images.githubusercontent.com/38932432/71574135-5e591400-2b22-11ea-986f-4baf01cdc5d1.png)
![copy_obj_2](https://user-images.githubusercontent.com/38932432/71574137-61540480-2b22-11ea-8135-65029da0ddf0.png)
4. Get object:
![get_obj](https://user-images.githubusercontent.com/38932432/71574152-75980180-2b22-11ea-8547-dbf4cb4d4fc5.jpg)
5. Delete object:
![delete_obj_1](https://user-images.githubusercontent.com/38932432/71574182-9e1ffb80-2b22-11ea-9a6e-c22449df5a80.jpg)
![delete_obj_2](https://user-images.githubusercontent.com/38932432/71574185-a37d4600-2b22-11ea-8fca-e218cbcef9d5.png)

```
