### PR TITLE
fix the bug that put object failed when using IBM Cos as the backend …

### DIFF
--- a/s3/pkg/datastore/ibm/factory.go
+++ b/s3/pkg/datastore/ibm/factory.go
@@ -16,5 +16,5 @@ func (factory *IBMCOSDriverFactory) CreateDriver(backend *backendpb.BackendDetai
 }
 
 func init() {
-	driver.RegisterDriverFactory(constants.BackendTypeAws, &IBMCOSDriverFactory{})
+	driver.RegisterDriverFactory(constants.BackendTypeIBMCos, &IBMCOSDriverFactory{})
 }

--- a/s3/pkg/service/object.go
+++ b/s3/pkg/service/object.go
@@ -557,6 +557,11 @@ func (s *s3Service) CopyObject(ctx context.Context, in *pb.CopyObjectRequest, ou
 	targetObject.Acl = &pb.Acl{CannedAcl: "private"}
 	// we only support copy data with sse but not support copy data without sse right now
 	targetObject.ServerSideEncryption = srcObject.ServerSideEncryption
+	if validTier(in.TargetTier) {
+		targetObject.Tier = in.TargetTier
+	} else {
+		targetObject.Tier = srcObject.Tier
+	}
 
 	err = s.MetaStorage.PutObject(ctx, &meta.Object{Object: targetObject}, oldObj, nil, nil, true)
 	if err != nil {


### PR DESCRIPTION
…and copied object tier is not correct

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #858 

**Special notes for your reviewer**:
Put and multipart put works fine:
![ibm_put](https://user-images.githubusercontent.com/38932432/71707178-864abf00-2e23-11ea-8e29-060bc3769a62.png)
Download works fine:
![multipart_put_ibm](https://user-images.githubusercontent.com/38932432/71707229-b85c2100-2e23-11ea-9cc1-e6ab86bcbc69.png)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
