### PR TITLE
fix the bug that downloading object failed

### DIFF
--- a/api/pkg/s3/objectcopy.go
+++ b/api/pkg/s3/objectcopy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/emicklei/go-restful"
 	"github.com/micro/go-micro/client"
 	"github.com/opensds/multi-cloud/api/pkg/common"
+	apiutils "github.com/opensds/multi-cloud/api/pkg/utils"
 	. "github.com/opensds/multi-cloud/s3/error"
 	"github.com/opensds/multi-cloud/s3/pkg/meta/types"
 	"github.com/opensds/multi-cloud/s3/pkg/utils"
@@ -184,7 +185,7 @@ func (s *APIService) ObjectCopy(request *restful.Request, response *restful.Resp
 
 	log.Infoln("srcBucket:", sourceBucketName, " srcObject:", sourceObjectName,
 		" targetBucket:", targetBucketName, " targetObject:", targetObjectName)
-	tmoutSec := sourceObject.Size / MiniSpeed
+	tmoutSec := apiutils.GetTimeoutSec(sourceObject.Size)
 	opt := client.WithRequestTimeout(time.Duration(tmoutSec) * time.Second)
 	result, err := s.s3Client.CopyObject(ctx, &pb.CopyObjectRequest{
 		SrcBucketName:    sourceBucketName,

--- a/api/pkg/s3/objectget.go
+++ b/api/pkg/s3/objectget.go
@@ -24,12 +24,11 @@ import (
 	"github.com/micro/go-micro/client"
 	"github.com/opensds/multi-cloud/api/pkg/common"
 	. "github.com/opensds/multi-cloud/api/pkg/s3/datatype"
+	"github.com/opensds/multi-cloud/api/pkg/utils"
 	s3error "github.com/opensds/multi-cloud/s3/error"
 	pb "github.com/opensds/multi-cloud/s3/proto"
 	log "github.com/sirupsen/logrus"
 )
-
-var MiniSpeed int64 = 5 // 5KByte/Sec
 
 // supportedGetReqParams - supported request parameters for GET presigned request.
 var supportedGetReqParams = map[string]string{
@@ -104,7 +103,7 @@ func (s *APIService) ObjectGet(request *restful.Request, response *restful.Respo
 		startOffset = hrange.OffsetBegin
 		length = hrange.GetLength()
 	}
-	tmoutSec := object.Size / MiniSpeed
+	tmoutSec := utils.GetTimeoutSec(object.Size)
 	opt := client.WithRequestTimeout(time.Duration(tmoutSec) * time.Second)
 	stream, err := s.s3Client.GetObject(ctx, &pb.GetObjectInput{Bucket: bucketName, Key: objectKey, Offset: startOffset, Length: length}, opt)
 	if err != nil {

--- a/api/pkg/utils/utils.go
+++ b/api/pkg/utils/utils.go
@@ -17,12 +17,16 @@ package utils
 import (
 	"encoding/json"
 	"errors"
+	"math"
 	"math/rand"
 	"os"
 	"reflect"
+	"strconv"
 
 	log "github.com/sirupsen/logrus"
 )
+
+const DEFAULT_TIMEOUT_SEC int64 = 5 // Same as the default timeout of go-micro.
 
 //remove redundant elements
 func RvRepElement(arr []string) []string {
@@ -194,4 +198,20 @@ func RandSeq(n int, chs []rune) string {
 		b[i] = chs[rand.Intn(len(chs))]
 	}
 	return string(b)
+}
+
+func GetTimeoutSec(objSize int64) int64 {
+	minSpeed, err := strconv.ParseInt(os.Getenv("TRANSFER_SPEED_MIN"), 10, 64)
+	if err != nil || minSpeed > math.MaxInt64 || minSpeed < 1 {
+		minSpeed = 1
+	}
+
+	tmoutSec := objSize / minSpeed
+	if tmoutSec < DEFAULT_TIMEOUT_SEC {
+		tmoutSec = DEFAULT_TIMEOUT_SEC
+	}
+
+	log.Debugf("tmoutSec=%d\n", tmoutSec)
+
+	return tmoutSec
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - OS_USERNAME=opensds
       - OS_PASSWORD=opensds@123
       - OS_PROJECT_NAME=service
+      - TRANSFER_SPEED_MIN=10   #Bytes/Sec
 
   backend:
     image: opensdsio/multi-cloud-backend


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is to fix the bug that downloading object failed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #887 

**Special notes for your reviewer**:
The root cause of this bug is the way to calculate timeout is not correct, if object size is less than 5Bytes, then the timeout will be 0, that is not right. So, in this PR, the way to calculate timeout is modified.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
